### PR TITLE
Switch to debian-11 gcc-9

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -36,7 +36,7 @@ def setup():
     if not os.path.isdir('wagerr'):
         subprocess.check_call(['git', 'clone', 'https://github.com/wagerr/wagerr.git'])
     os.chdir('gitian-builder')
-    make_image_prog = ['bin/make-base-vm', '--distro', 'debian' '--suite', 'buster', '--arch', 'amd64']
+    make_image_prog = ['bin/make-base-vm', '--distro', 'debian' '--suite', 'bullseye', '--arch', 'amd64']
     if args.docker:
         make_image_prog += ['--docker']
     elif args.lxc:

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -3,7 +3,7 @@ name: "wagerr-linux-5.0.99"
 enable_cache: true
 distro: "debian"
 suites:
-- "buster"
+- "bullseye"
 architectures:
 - "amd64"
 packages:
@@ -16,8 +16,8 @@ packages:
 - "ca-certificates"
 - "curl"
 - "faketime"
-- "g++-8"
-- "gcc-8"
+- "g++-9"
+- "gcc-9"
 - "git"
 - "libtool"
 - "patch"
@@ -25,16 +25,16 @@ packages:
 - "python3"
 - "libxkbcommon0"
 - "ccache"
-- "g++-8-multilib"
-- "gcc-8-multilib"
+- "g++-9-multilib"
+- "gcc-9-multilib"
 - "binutils-gold"
 # Cross compilation HOSTS:
 #  - aarch64-linux-gnu
 - "binutils-aarch64-linux-gnu"
-- "g++-8-aarch64-linux-gnu"
+- "g++-9-aarch64-linux-gnu"
 #  - arm-linux-gnueabihf
 - "binutils-arm-linux-gnueabihf"
-- "g++-8-arm-linux-gnueabihf"
+- "g++-9-arm-linux-gnueabihf"
 remotes:
 - "url": "https://github.com/wagerr/wagerr.git"
   "dir": "wagerr"
@@ -97,11 +97,11 @@ script: |
   function create_per-host_faketime_wrappers {
   for i in $HOSTS; do
     for prog in ${FAKETIME_HOST_PROGS}; do
-        if which ${i}-${prog}-8
+        if which ${i}-${prog}-9
         then
             echo '#!/usr/bin/env bash' > ${WRAP_DIR}/${i}-${prog}
             echo "# GCCVERSION=${GCCVERSION}" >> ${WRAP_DIR}/${i}-${prog}
-            echo "REAL=\`which -a ${i}-${prog}-8 | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
+            echo "REAL=\`which -a ${i}-${prog}-9 | grep -v ${WRAP_DIR}/${i}-${prog} | head -1\`" >> ${WRAP_DIR}/${i}-${prog}
             echo "export LD_PRELOAD='/usr/\$LIB/faketime/libfaketime.so.1'" >> ${WRAP_DIR}/${i}-${prog}
             echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${i}-${prog}
             echo "\$REAL \$@" >> $WRAP_DIR/${i}-${prog}
@@ -122,7 +122,7 @@ script: |
   BASEPREFIX="${PWD}/depends"
   # Build dependencies for each host
   for i in $HOSTS; do
-    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}" CC=${i}-gcc-8 CXX=${i}-g++-8
+    make ${MAKEOPTS} -C ${BASEPREFIX} HOST="${i}" CC=${i}-gcc-9 CXX=${i}-g++-9
   done
 
   # Faketime for binaries
@@ -159,7 +159,7 @@ script: |
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
     ./autogen.sh
-    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" CC=${i}-gcc-8 CXX=${i}-g++-8
+    CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}" CC=${i}-gcc-9 CXX=${i}-g++-9
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     # make check-symbols no longer works

--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -2,7 +2,7 @@
 name: "wagerr-dmg-signer"
 distro: "debian"
 suites:
-- "buster"
+- "bullseye"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -3,7 +3,7 @@ name: "wagerr-osx-5.0.99"
 enable_cache: true
 distro: "debian"
 suites:
-- "buster"
+- "bullseye"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -2,7 +2,7 @@
 name: "wagerr-win-signer"
 distro: "debian"
 suites:
-- "buster"
+- "bullseye"
 architectures:
 - "amd64"
 packages:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -3,12 +3,12 @@ name: "wagerr-win-5.0.99"
 enable_cache: true
 distro: "debian"
 suites:
-- "buster"
+- "bullseye"
 architectures:
 - "amd64"
 packages:
 - "curl"
-- "g++"
+- "g++-9"
 - "git"
 - "pkg-config"
 - "autoconf"


### PR DESCRIPTION
Use debian-11 (bullseye) with gxx-9 to build with gitian-build.py