### PR TITLE
Change from debug -O1 to debug -O0

### DIFF
--- a/depends/hosts/linux.mk
+++ b/depends/hosts/linux.mk
@@ -4,7 +4,7 @@ linux_CXXFLAGS=$(linux_CFLAGS) -static-libstdc++
 linux_release_CFLAGS=-O2
 linux_release_CXXFLAGS=$(linux_release_CFLAGS)
 
-linux_debug_CFLAGS=-O1
+linux_debug_CFLAGS=-O0
 linux_debug_CXXFLAGS=$(linux_debug_CFLAGS)
 
 linux_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC -D_LIBCPP_DEBUG=1

--- a/depends/hosts/mingw32.mk
+++ b/depends/hosts/mingw32.mk
@@ -4,7 +4,7 @@ mingw32_CXXFLAGS=$(mingw32_CFLAGS) -static-libstdc++
 mingw32_release_CFLAGS=-O2
 mingw32_release_CXXFLAGS=$(mingw32_release_CFLAGS)
 
-mingw32_debug_CFLAGS=-O1
+mingw32_debug_CFLAGS=-O0
 mingw32_debug_CXXFLAGS=$(mingw32_debug_CFLAGS)
 
 mingw32_debug_CPPFLAGS=-D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC


### PR DESCRIPTION
Enable optimization to run at level 0 rather than level 1 for debugging purposes