### PR TITLE
Add feature-betting tests scripts

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -662,7 +662,7 @@ public:
         consensus.nGovernanceMinQuorum = 1;
         consensus.nGovernanceFilterElements = 500;
         consensus.nMasternodeMinimumConfirmations = 1;
-        consensus.V18DeploymentHeight = 600;
+        consensus.V18DeploymentHeight = 500;
         consensus.BIP34Height = 1; // BIP34 activated immediately on devnet
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1; // BIP65 activated immediately on devnet

--- a/test/functional/feature_betting.py
+++ b/test/functional/feature_betting.py
@@ -1,0 +1,1844 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.betting_opcode import *
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import WagerrTestFramework
+from test_framework.util import wait_until, rpc_port, assert_equal, assert_raises_rpc_error, sync_blocks, connect_nodes, disconnect_nodes
+from distutils.dir_util import copy_tree, remove_tree
+from decimal import *
+import pprint
+import time
+import os
+import ctypes
+
+WGR_WALLET_ORACLE = { "addr": "TXuoB9DNEuZx1RCfKw3Hsv7jNUHTt4sVG1", "key": "TBwvXbNNUiq7tDkR2EXiCbPxEJRTxA1i6euNyAE9Ag753w36c1FZ" }
+WGR_WALLET_EVENT = { "addr": "TFvZVYGdrxxNunQLzSnRSC58BSRA7si6zu", "key": "TCDjD2i4e32kx2Fc87bDJKGBedEyG7oZPaZfp7E1PQG29YnvArQ8" }
+WGR_WALLET_DEV = { "addr": "TLuTVND9QbZURHmtuqD5ESECrGuB9jLZTs", "key": "TFCrxaUt3EjHzMGKXeBqA7sfy3iaeihg5yZPSrf9KEyy4PHUMWVe" }
+WGR_WALLET_OMNO = { "addr": "THofaueWReDjeZQZEECiySqV9GP4byP3qr", "key": "TDJnwRkSk8JiopQrB484Ny9gMcL1x7bQUUFFFNwJZmmWA7U79uRk" }
+
+sport_names = ["Football", "MMA", "CSGO", "DOTA2", "Test Sport", "V2-V3 Sport", "ML Sport One", "Spread Sport"]
+round_names = ["round1", "round2", "round3", "round4"]
+tournament_names = ["UEFA Champions League", "UFC244", "PGL Major Krakow", "EPICENTER Major", "Test Tournament", "V2-V3 Tournament", "ML Tournament One", "Spread Tournament"]
+team_names = ["Real Madrid", "Barcelona", "Jorge Masvidal", "Nate Diaz", "Astralis", "Gambit", "Virtus Pro", "Team Liquid", "Test Team1", "Test Team2","V2-V3 Team1", "V2-V3 Team2", "ML Team One", "ML Team Two", "Spread Team One", "Spread Team Two"]
+
+outcome_home_win = 1
+outcome_away_win = 2
+outcome_draw = 3
+outcome_spread_home = 4
+outcome_spread_away = 5
+outcome_total_over = 6
+outcome_total_under = 7
+
+def check_bet_payouts_info(listbets, listpayoutsinfo):
+    for bet in listbets:
+        info_found = False
+        for info in listpayoutsinfo:
+            info_type = info['payoutInfo']['payoutType']
+            if info_type == 'Betting Payout' or info_type == 'Betting Refund':
+                if info['payoutInfo']['betBlockHeight'] == bet['betBlockHeight']:
+                    if info['payoutInfo']['betTxHash'] == bet['betTxHash']:
+                        if info['payoutInfo']['betTxOut'] == bet['betTxOut']:
+                            info_found = True
+        assert(info_found)
+
+class BettingTest(WagerrTestFramework):
+    def get_cache_dir_name(self, node_index, block_count):
+        return ".test-chain-{0}-{1}-.node{2}".format(self.num_nodes, block_count, node_index)
+
+    def get_node_setting(self, node_index, setting_name):
+        with open(os.path.join(self.nodes[node_index].datadir, "wagerr.conf"), 'r', encoding='utf8') as f:
+            for line in f:
+                if line.startswith(setting_name + "="):
+                    return line.split("=")[1].strip("\n")
+        return None
+
+    def get_local_peer(self, node_index, is_rpc=False):
+        port = self.get_node_setting(node_index, "rpcport" if is_rpc else "port")
+        return "127.0.0.1:" + str(rpc_port(node_index) if port is None else port)
+
+    def sync_node_datadir(self, node_index, left, right):
+        node = self.nodes[node_index]
+        node.stop_node()
+        node.wait_until_stopped()
+        if not left:
+            left = self.nodes[node_index].datadir
+        if not right:
+            right = self.nodes[node_index].datadir
+        if os.path.isdir(right):
+            remove_tree(right)
+        copy_tree(left, right)
+        node.rpchost = self.get_local_peer(node_index, True)
+        node.start(self.extra_args)
+        node.wait_for_rpc_connection()
+
+    def set_test_params(self):
+        self.extra_args = [ ['-sporkkey=6xLZdACFRA53uyxz8gKDLcgVrm5kUUEu2B3BUzWUxHqa2W7irbH', '-minrelaytxfee=0.00000001', '-mintxfee=0.00000001', '-paytxfee=0.01'],
+                            ['-sporkkey=6xLZdACFRA53uyxz8gKDLcgVrm5kUUEu2B3BUzWUxHqa2W7irbH', '-minrelaytxfee=0.00000001', '-mintxfee=0.00000001', '-paytxfee=0.01'],
+                            ['-sporkkey=6xLZdACFRA53uyxz8gKDLcgVrm5kUUEu2B3BUzWUxHqa2W7irbH', '-minrelaytxfee=0.00000001', '-mintxfee=0.00000001', '-paytxfee=0.01'],
+                            ['-sporkkey=6xLZdACFRA53uyxz8gKDLcgVrm5kUUEu2B3BUzWUxHqa2W7irbH', '-minrelaytxfee=0.00000001', '-mintxfee=0.00000001', '-paytxfee=0.01'] ]
+
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+        self.players = []
+
+    def connect_network(self):
+        for pair in [[n, n + 1 if n + 1 < self.num_nodes else 0] for n in range(self.num_nodes)]:
+            for i in range(len(pair)):
+                assert i < 2
+                self.nodes[pair[i]].addnode(self.get_local_peer(pair[1 - i]), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[pair[i]].getpeerinfo()))
+        self.sync_all()
+        for n in range(self.num_nodes):
+            idx_l = n
+            idx_r = n + 1 if n + 1 < self.num_nodes else 0
+            assert_equal(self.nodes[idx_l].getblockcount(), self.nodes[idx_r].getblockcount())
+
+    def connect_and_sync_blocks(self):
+        for pair in [[n, n + 1 if n + 1 < self.num_nodes else 0] for n in range(self.num_nodes)]:
+            for i in range(len(pair)):
+                assert i < 2
+                self.nodes[pair[i]].addnode(self.get_local_peer(pair[1 - i]), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[pair[i]].getpeerinfo()))
+        sync_blocks(self.nodes)
+
+    def setup_network(self):
+        self.log.info("Setup Network")
+        self.setup_nodes()
+
+    def save_cache(self, force=False):
+        dir_names = dict()
+        for n in range(self.num_nodes):
+            dir_name = self.get_cache_dir_name(n, self.nodes[n].getblockcount())
+            if force or not os.path.isdir(dir_name):
+                dir_names[n] = dir_name
+        if len(dir_names) > 0:
+            for node_index in dir_names.keys():
+                self.sync_node_datadir(node_index, None, dir_names[node_index])
+            self.connect_network()
+
+    def load_cache(self, block_count):
+        dir_names = dict()
+        for n in range(self.num_nodes):
+            dir_name = self.get_cache_dir_name(n, block_count)
+            if os.path.isdir(dir_name):
+                dir_names[n] = dir_name
+        if len(dir_names) == self.num_nodes:
+            for node_index in range(self.num_nodes):
+                self.sync_node_datadir(node_index, dir_names[node_index], None)
+            self.connect_network()
+            return True
+        return False
+
+    def is_spork_active(self, spork_name):
+        sporks = self.nodes[0].spork("active")
+        return sporks[spork_name]
+
+    def activate_spork(self, spork_name):
+        for node in self.nodes:
+            res = node.spork(spork_name, 1)
+            assert(res == "success")
+
+    def deactivate_spork(self, spork_name):
+        for node in self.nodes:
+            res = node.spork(spork_name, 4070908800)
+            assert(res == "success")
+
+
+    def check_minting(self, block_count=250):
+        self.log.info("Check Minting...")
+
+        self.nodes[1].importprivkey(WGR_WALLET_ORACLE['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_EVENT['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_DEV['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_OMNO['key'])
+
+        self.players.append(self.nodes[2].getnewaddress('Node2Addr'))
+        self.players.append(self.nodes[3].getnewaddress('Node3Addr'))
+
+        for i in range(block_count - 1):
+            blocks = self.nodes[0].generate(1)
+            blockinfo = self.nodes[0].getblock(blocks[0])
+            # get coinbase tx
+            rawTx = self.nodes[0].getrawtransaction(blockinfo['tx'][0])
+            decodedTx = self.nodes[0].decoderawtransaction(rawTx)
+            address = decodedTx['vout'][0]['scriptPubKey']['addresses'][0]
+            #if (i > 0):
+                # minting must process to sigle address
+                #assert_equal(address, prevAddr)
+            prevAddr = address
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 3)
+        self.sync_all()
+        self.log.info("Synced...")
+
+
+        for i in range(20):
+            self.nodes[0].sendtoaddress(WGR_WALLET_ORACLE['addr'], 2000)
+            self.nodes[0].sendtoaddress(WGR_WALLET_EVENT['addr'], 2000)
+            self.nodes[0].sendtoaddress(self.players[0], 2000)
+            self.nodes[0].sendtoaddress(self.players[1], 2000)
+
+        self.nodes[0].generate(51)
+        self.sync_all()
+
+        for n in range(self.num_nodes):
+            assert_equal( self.nodes[n].getblockcount(), 300)
+
+        # check oracle balance
+        assert_equal(self.nodes[1].getbalance(), 80000)
+        # check players balance
+        assert_equal(self.nodes[2].getbalance(), 40000)
+        assert_equal(self.nodes[3].getbalance(), 40000)
+
+        self.log.info("Minting Success")
+
+    def check_mapping(self):
+        self.log.info("Check Mapping...")
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingid, "", "")
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingname, "abc123", 0)
+
+        # add sports to mapping
+        for id in range(len(sport_names)):
+            mapping_opcode = make_mapping(SPORT_MAPPING, id, sport_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # generate block for unlocking used Oracle's UTXO
+        self.sync_all()
+        self.nodes[0].generate(1)
+        for n in range(self.num_nodes):
+            self.stop_node(n)
+            self.start_node(n, ["-reindex"])
+        disconnect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[0], 2)
+        disconnect_nodes(self.nodes[0], 3)
+        connect_nodes(self.nodes[0], 3)
+        self.sync_all()
+
+        # add rounds to mapping
+        for id in range(len(round_names)):
+            mapping_opcode = make_mapping(ROUND_MAPPING, id, round_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # generate block for unlocking used Oracle's UTXO
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # add teams to mapping
+        for id in range(len(team_names)):
+            mapping_opcode = make_mapping(TEAM_MAPPING, id, team_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # generate block for unlocking used Oracle's UTXO
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # add tournaments to mapping
+        for id in range(len(tournament_names)):
+            mapping_opcode = make_mapping(TOURNAMENT_MAPPING, id, tournament_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            # Check sports mapping
+            for id in range(len(sport_names)):
+                mapping = node.getmappingname("sports", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], sport_names[id])
+                assert_equal(mapping['mapping-type'], "sports")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("sports", sport_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "sports")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check rounds mapping
+            for id in range(len(round_names)):
+                mapping = node.getmappingname("rounds", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], round_names[id])
+                assert_equal(mapping['mapping-type'], "rounds")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("rounds", round_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "rounds")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check teams mapping
+            for id in range(len(team_names)):
+                mapping = node.getmappingname("teamnames", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], team_names[id])
+                assert_equal(mapping['mapping-type'], "teamnames")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("teamnames", team_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "teamnames")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check tournaments mapping
+            for id in range(len(tournament_names)):
+                mapping = node.getmappingname("tournaments", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], tournament_names[id])
+                assert_equal(mapping['mapping-type'], "tournaments")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("tournaments", tournament_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "tournaments")
+                assert_equal(mappingid['mapping-id'], id)
+        self.log.info("Mapping Success")
+
+    def check_event(self):
+        self.log.info("Check Event creation...")
+
+        self.start_time = int(time.time() + 60 * 60)
+        # array for odds of events
+        self.odds_events = []
+
+        # 0: Football - UEFA Champions League - Real Madrid vs Barcelona
+        mlevent = make_event(0, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("Football"), # Sport ID
+                            tournament_names.index("UEFA Champions League"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Real Madrid"), # Home Team
+                            team_names.index("Barcelona"), # Away Team
+                            15000, # home odds
+                            18000, # away odds
+                            13000) # draw odds
+        self.odds_events.append({'homeOdds': 15000, 'awayOdds': 18000, 'drawOdds': 13000})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        # 1: MMA - UFC244 - Jorge Masvidal vs Nate Diaz
+        mlevent = make_event(1, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("MMA"), # Sport ID
+                            tournament_names.index("UFC244"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Jorge Masvidal"), # Home Team
+                            team_names.index("Nate Diaz"), # Away Team
+                            14000, # home odds
+                            28000, # away odds
+                            50000) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 28000, 'drawOdds': 50000})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        # 2: CSGO - PGL Major Krakow - Astralis vs Gambit
+        mlevent = make_event(2, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("CSGO"), # Sport ID
+                            tournament_names.index("PGL Major Krakow"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Astralis"), # Home Team
+                            team_names.index("Gambit"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 33000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+        # 3: DOTA2 - EPICENTER Major - Virtus Pro vs Team Liquid
+        mlevent = make_event(3, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("DOTA2"), # Sport ID
+                            tournament_names.index("EPICENTER Major"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Virtus Pro"), # Home Team
+                            team_names.index("Team Liquid"), # Away Team
+                            24000, # home odds
+                            17000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 24000, 'awayOdds': 17000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+
+        self.nodes[0].generate(1)
+
+        self.sync_all()
+
+        for node in self.nodes:
+            list_events = node.listevents()
+            found_events = 0
+            for event in list_events:
+                event_id = event['event_id']
+                assert_equal(event['sport'], sport_names[event_id])
+                assert_equal(event['tournament'], tournament_names[event_id])
+                assert_equal(event['teams']['home'], team_names[2 * event_id])
+                assert_equal(event['teams']['away'], team_names[(2 * event_id) + 1])
+
+                found_events = found_events | (1 << event['event_id'])
+            # check that all events found
+            assert_equal(found_events, 0b1111)
+
+        self.log.info("Event creation Success")
+
+    def check_event_patch(self):
+        self.log.info("Check Event Patch...")
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                assert_equal(event['starting'], self.start_time)
+
+        self.start_time = int(time.time() + 60 * 20) # new time - curr + 20mins
+
+        for event in events:
+            event_patch = make_event_patch(event['event_id'], self.start_time)
+            post_opcode(self.nodes[1], event_patch, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                assert_equal(event['starting'], self.start_time)
+
+        self.log.info("Event Patch Success")
+
+    def check_update_odds(self):
+        self.log.info("Check updating odds...")
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                event_id = event['event_id']
+                # 0 mean ml odds in odds array
+                assert_equal(event['odds'][0]['mlHome'], self.odds_events[event_id]['homeOdds'])
+                assert_equal(event['odds'][0]['mlAway'], self.odds_events[event_id]['awayOdds'])
+                assert_equal(event['odds'][0]['mlDraw'], self.odds_events[event_id]['drawOdds'])
+
+        # Change odd for event 1 - UFC244
+        event_id = tournament_names.index("UFC244")
+        self.odds_events[event_id]['homeOdds'] = 16000
+        self.odds_events[event_id]['awayOdds'] = 25000
+        self.odds_events[event_id]['drawOdds'] = 80000
+        update_odds_opcode = make_update_ml_odds(event_id,
+                                                self.odds_events[event_id]['homeOdds'],
+                                                self.odds_events[event_id]['awayOdds'],
+                                                self.odds_events[event_id]['drawOdds'])
+        post_opcode(self.nodes[1], update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                event_id = event['event_id']
+                # 0 mean ml odds in odds array
+                assert_equal(event['odds'][0]['mlHome'], self.odds_events[event_id]['homeOdds'])
+                assert_equal(event['odds'][0]['mlAway'], self.odds_events[event_id]['awayOdds'])
+                assert_equal(event['odds'][0]['mlDraw'], self.odds_events[event_id]['drawOdds'])
+
+        self.log.info("Updating odds Success")
+
+    def check_spread_event(self):
+        self.log.info("Check Spread events...")
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                # 1 mean spreads odds in odds array
+                assert_equal(event['odds'][1]['spreadPoints'], 0)
+                assert_equal(event['odds'][1]['spreadHome'], 0)
+                assert_equal(event['odds'][1]['spreadAway'], 0)
+        # make spread for event 0: UEFA Champions League
+        spread_event_opcode = make_spread_event(0, 1, 28000, 14000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                if event['event_id'] == 0:
+                    assert_equal(event['odds'][1]['spreadPoints'], 1)
+                    assert_equal(event['odds'][1]['spreadHome'], 28000)
+                    assert_equal(event['odds'][1]['spreadAway'], 14000)
+
+        self.log.info("Spread events Success")
+
+    def check_spread_event_v2(self):
+        self.log.info("Check Spread v2 events...")
+        mlevent = make_event(4, # Event ID
+                             self.start_time, # start time = current + hour
+                             sport_names.index("DOTA2"), # Sport ID
+                             tournament_names.index("EPICENTER Major"), # Tournament ID
+                             round_names.index("round1"), # Round ID
+                             team_names.index("Virtus Pro"), # Home Team
+                             team_names.index("Team Liquid"), # Away Team
+                             10000, # home odds
+                             30000, # away odds
+                             0) # draw odds
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                if event['event_id'] == 4:
+                    assert_equal(event['odds'][1]['spreadPoints'], 0)
+                    assert_equal(event['odds'][1]['spreadHome'], 0)
+                    assert_equal(event['odds'][1]['spreadAway'], 0)
+        # make spread for event 4: DOTA2
+        spread_event_opcode = make_spread_event(4, 150, 25000, 15000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                if event['event_id'] == 4:
+                    assert_equal(event['odds'][1]['spreadPoints'], 150)
+                    assert_equal(event['odds'][1]['spreadHome'], 25000)
+                    assert_equal(event['odds'][1]['spreadAway'], 15000)
+
+        # make spread for event 4: DOTA2
+        spread_event_opcode_negative = make_spread_event(4, -250, 27000, 13000)
+        post_opcode(self.nodes[1], spread_event_opcode_negative, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                if event['event_id'] == 4:
+                    tmp = event['odds'][1]['spreadPoints']
+                    assert_equal(ctypes.c_long(tmp).value, -250)
+                    assert_equal(event['odds'][1]['spreadHome'], 27000)
+                    assert_equal(event['odds'][1]['spreadAway'], 13000)
+
+        self.log.info("Spread v2 events Success")
+
+    def check_total_event(self):
+        self.log.info("Check Total events...")
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                # 2 mean totals odds in odds array
+                assert_equal(event['odds'][2]['totalsPoints'], 0)
+                assert_equal(event['odds'][2]['totalsOver'], 0)
+                assert_equal(event['odds'][2]['totalsUnder'], 0)
+
+        # make totals for event 2: PGL Major Krakow
+        totals_event_opcode = make_total_event(2, 26, 21000, 23000)
+        post_opcode(self.nodes[1], totals_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        for node in self.nodes:
+            events = node.listevents()
+            for event in events:
+                if event['event_id'] == 2:
+                    assert_equal(event['odds'][2]['totalsPoints'], 26)
+                    assert_equal(event['odds'][2]['totalsOver'], 21000)
+                    assert_equal(event['odds'][2]['totalsUnder'], 23000)
+
+        self.log.info("Total events Success")
+
+    def check_ml_bet(self):
+        self.log.info("Check Money Line Bets...")
+
+        global player1_total_bet
+        player1_total_bet = 0
+        global player2_total_bet
+        player2_total_bet = 0
+
+        # place bet to ml event 3 with incorrect amounts
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 3, outcome_away_win, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 3, outcome_away_win, 10001)
+        # place bet to ml event 3: DOTA2 - EPICENTER Major - Virtus Pro vs Team Liquid
+        # player 1 bet to Team Liquid with odds 17000
+        player1_bet = 100
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(3, outcome_away_win, player1_bet)
+        winnings = Decimal(player1_bet * self.odds_events[3]['awayOdds'])
+        player1_expected_win = (winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        # change odds
+        self.odds_events[3]['homeOdds'] = 28000
+        self.odds_events[3]['awayOdds'] = 14000
+        self.odds_events[3]['drawOdds'] = 0
+        update_odds_opcode = make_update_ml_odds(3,
+                                                self.odds_events[3]['homeOdds'],
+                                                self.odds_events[3]['awayOdds'],
+                                                self.odds_events[3]['drawOdds'])
+        post_opcode(self.nodes[1], update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        #player 2 bet to Team Liquid with incorrect bets.
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 3, outcome_away_win, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 3, outcome_away_win, 10001)
+        #player 2 bet to Team Liquid with odds 14000
+        player2_bet = 200
+        player2_total_bet = player2_total_bet + player2_bet
+        self.nodes[3].placebet(3, outcome_away_win, player2_bet)
+        winnings = Decimal(player2_bet * self.odds_events[3]['awayOdds'])
+        player2_expected_win = (winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(3))
+        liability=self.nodes[0].geteventliability(3)
+        gotliability=liability["moneyline-away-liability"]
+        #self.log.info("Monyline Away %s" % liability["moneyline-away-liability"])
+        assert_equal(gotliability, Decimal(165))
+        # place result for event 3: Team Liquid wins.
+        result_opcode = make_result(3, STANDARD_RESULT, 0, 1)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+        self.sync_all()
+        #print("Player 1 Total Bet", player1_total_bet)
+        #print("Player 2 Total Bet", player2_total_bet)
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+        #self.log.info("Listbets")
+        #pprint.pprint(listbets)
+        #self.log.info("Payouts Info")
+        #pprint.pprint(payoutsInfo)
+
+        check_bet_payouts_info(listbets, payoutsInfo)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        # create losing bet
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player1_bet = 200
+        player1_total_bet = player1_total_bet + player1_bet
+        player1_txid=(self.nodes[2].placebet(1, outcome_home_win, player1_bet))
+        player1_expected_loss = Decimal(200)
+        player1_transaction=self.nodes[2].gettransaction(player1_txid)
+        player1_bet_cost=0
+        for transaction in player1_transaction['details']:
+            player1_bet_cost=player1_bet_cost + transaction['fee']
+
+        #self.log.info("Bet Cost %s" % player1_bet_cost)
+        #self.log.info("Expected Loss  %d" % player1_expected_loss)
+
+        # create draw bet (will show up as a win)
+        player2_bet = 150
+        player2_total_bet = player2_total_bet + player2_bet
+
+        self.nodes[3].placebet(1, outcome_draw, player2_bet)
+        winnings = Decimal(player2_bet * self.odds_events[1]['drawOdds'])
+        player2_expected_win = (winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        self.nodes[3].generate(5)
+        self.sync_all()
+
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(1))
+        liability=self.nodes[0].geteventliability(1)
+        gotliability=liability["moneyline-draw-liability"]
+        assert_equal(gotliability, Decimal(1137))
+        gotliability=liability["moneyline-home-liability"]
+        assert_equal(gotliability, Decimal(312))
+
+        # close event 1
+        result_opcode = make_result(1, STANDARD_RESULT, 1, 1)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+       # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+        self.sync_all()
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal((player1_balance_before - player1_expected_loss + player1_bet_cost), player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        self.log.info("Money Line Bets Success")
+
+    def check_spreads_bet(self):
+        self.log.info("Check Spread Bets...")
+
+        global player1_total_bet
+        global player2_total_bet
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 0, outcome_spread_home, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 0, outcome_spread_home, 10001)
+        # place spread bet to event 0: UEFA Champions League, expect that event result will be 2:0 for home team
+        # player 1 bet to spread home, mean that home will win with spread points for away = 1
+        player1_bet = 300
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(0, outcome_spread_home, player1_bet)
+        winnings = Decimal(player1_bet * 28000)
+        player1_expected_win = (winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        # change spread condition for event 0
+        spread_event_opcode = make_spread_event(0, 2, 23000, 15000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 0, outcome_spread_home, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 0, outcome_spread_home, 10001)
+        # player 2 bet to spread home, mean that home will win with spread points for away = 2
+        # for our results it means refund
+        player2_bet = 200
+        player2_total_bet = player2_total_bet + player2_bet
+        self.nodes[3].placebet(0, outcome_spread_home, player2_bet)
+        winnings = Decimal(player2_bet * ODDS_DIVISOR)
+        player2_expected_win = (winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(0))
+        liability=self.nodes[0].geteventliability(0)
+        gotliability=liability["moneyline-draw-liability"]
+        assert_equal(gotliability, Decimal(1137))
+        gotliability=liability["moneyline-home-liability"]
+        assert_equal(gotliability, Decimal(312))
+
+
+        # place result for event 0: RM wins BARC with 2:0.
+        result_opcode = make_result(0, STANDARD_RESULT, 2, 0)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+
+        self.sync_all()
+        #print("Player 1 Total Bet", player1_total_bet)
+        #print("Player 2 Total Bet", player2_total_bet)
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+
+        check_bet_payouts_info(listbets, payoutsInfo)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        self.log.info("Spread Bets Success")
+
+    def check_spreads_bet_v2(self):
+        self.log.info("Check Spread Bets v2...")
+
+        global player1_total_bet
+        global player2_total_bet
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 4, outcome_spread_away, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 4, outcome_spread_away, 10001)
+
+        # place spread bet to event 4: EPICENTER Major, expect that event result will be 2:0 for away team
+        # current spread event is: points=-250, homeOdds=27000, awayOdds=13000
+        # player 1 bet to spread away, mean that away will not lose with diff more then 1 score
+        player1_bet = 300
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(4, outcome_spread_away, player1_bet)
+        winnings = Decimal(player1_bet * 13000)
+        player1_expected_win = (winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        # change spread condition for event 4
+        spread_event_opcode = make_spread_event(4, -200, 29000, 12000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 4, outcome_spread_home, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 4, outcome_spread_home, 10001)
+        # player 2 bet to spread home, mean that home will win with 2 extra scores
+        # for our results it means refund
+        player2_bet = 200
+        player2_total_bet = player2_total_bet + player2_bet
+        self.nodes[3].placebet(4, outcome_spread_home, player2_bet)
+        winnings = Decimal(player2_bet * ODDS_DIVISOR)
+        player2_expected_win = (winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        liability=self.nodes[0].geteventliability(4)
+        gotliability=liability["spread-away-liability"]
+        assert_equal(gotliability, Decimal(384))
+        gotliability=liability["spread-home-liability"]
+        assert_equal(gotliability, Decimal(557))
+        gotliability=liability["spread-push-liability"]
+        assert_equal(gotliability, Decimal(500))
+
+        # place result for event 4:
+        result_opcode = make_result(4, STANDARD_RESULT, 200, 0)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+
+        self.sync_all()
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        # Check edge cases
+        sprevent = make_event(11, # Event ID
+                    self.start_time, # start time = current + hour
+                    sport_names.index("Spread Sport"), # Sport ID
+                    tournament_names.index("Spread Tournament"), # Tournament ID
+                    round_names.index("round2"), # Round ID
+                    team_names.index("Spread Team One"), # Home Team
+                    team_names.index("Spread Team Two"), # Away Team
+                    15000, # home odds
+                    18000, # away odds
+                    13000) # draw odds
+
+        post_opcode(self.nodes[1], sprevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # create spread event
+        spread_event_opcode = make_spread_event(11, -125, 14000, 26000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        self.log.info("Spread Bets v2 Success")
+
+    def check_totals_bet(self):
+        self.log.info("Check Total Bets...")
+
+        global player1_total_bet
+        player1_total_bet = 0
+        global player2_total_bet
+        player2_total_bet = 0
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 2, outcome_total_over, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 2, outcome_total_over, 10001)
+        # place spread bet to event 2: PGL Major Krakow
+        # player 1 bet to total over with odds 21000
+        player1_bet = 200
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(2, outcome_total_over, player1_bet)
+        winnings = Decimal(player1_bet * 21000)
+        player1_expected_win =(winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+        # change totals condition for event 2
+        total_event_opcode = make_total_event(2, 28, 28000, 17000)
+        post_opcode(self.nodes[1], total_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[3].placebet, 2, outcome_total_under, 24)
+        assert_raises_rpc_error(-131, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.", self.nodes[2].placebet, 2, outcome_total_under, 10001)
+        # player 2 bet to total under with odds 17000
+        player2_bet = 200
+        player2_total_bet = player2_total_bet + player2_bet
+        self.nodes[3].placebet(2, outcome_total_under, player2_bet)
+        winnings = Decimal(player2_bet * 17000)
+        player2_expected_win = (winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(2))
+        liability=self.nodes[0].geteventliability(2)
+        gotliability=liability["total-over-liability"]
+        assert_equal(gotliability, Decimal(406))
+        gotliability=liability["total-push-liability"]
+        assert_equal(gotliability, Decimal(200))
+
+        # place result for event 2: Gambit wins with score 11:16
+        result_opcode = make_result(2, STANDARD_RESULT, 11, 16)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+        self.sync_all()
+        #print("Player 1 Total Bet", player1_total_bet)
+        #print("Player 2 Total Bet", player2_total_bet)
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+
+        check_bet_payouts_info(listbets, payoutsInfo)
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win , player2_balance_after)
+
+        self.log.info("Total Bets Success")
+
+    def check_parlays_bet(self):
+        self.log.info("Check Parlay Bets...")
+
+        global player1_total_bet
+        global player2_total_bet
+
+        # add new events
+        # 5: CSGO - PGL Major Krakow - Astralis vs Gambit round1
+        mlevent = make_event(5, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("CSGO"), # Sport ID
+                            tournament_names.index("PGL Major Krakow"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Astralis"), # Home Team
+                            team_names.index("Gambit"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 33000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        # 6: CSGO - PGL Major Krakow - Astralis vs Gambit round1
+        mlevent = make_event(6, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("CSGO"), # Sport ID
+                            tournament_names.index("PGL Major Krakow"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Astralis"), # Home Team
+                            team_names.index("Gambit"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 33000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        # 7: Football - UEFA Champions League - Barcelona vs Real Madrid round1
+        mlevent = make_event(7, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("Football"), # Sport ID
+                            tournament_names.index("UEFA Champions League"), # Tournament ID
+                            round_names.index("round1"), # Round ID
+                            team_names.index("Barcelona"), # Home Team
+                            team_names.index("Real Madrid"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 33000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        # 81: Football - UEFA Champions League - Barcelona vs Real Madrid round2
+        mlevent = make_event(81, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("Football"), # Sport ID
+                            tournament_names.index("UEFA Champions League"), # Tournament ID
+                            round_names.index("round2"), # Round ID
+                            team_names.index("Barcelona"), # Home Team
+                            team_names.index("Real Madrid"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        self.odds_events.append({'homeOdds': 14000, 'awayOdds': 33000, 'drawOdds': 0})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+         # player 1 make express to nonexistent events
+        #assert_raises_rpc_error(-131, "Error: there is no such Event: 501", self.nodes[2].placeparlaybet,
+        #    [
+        #        {'eventId': 5, 'outcome': outcome_home_win},
+        #        {'eventId': 6, 'outcome': outcome_home_win},
+        #        {'eventId': 501, 'outcome': outcome_home_win} # failed
+        #    ], 100)
+
+        # player 1 make express to events 6, 7, 81 - home win
+        #player1_bet = 200
+        #assert_raises_rpc_error(-131, "Error: event 81 cannot be part of parlay bet", self.nodes[2].placeparlaybet,
+        #    [
+        #        {'eventId': 6, 'outcome': outcome_home_win},
+        #        {'eventId': 7, 'outcome': outcome_home_win},
+        #        {'eventId': 81, 'outcome': outcome_home_win} # failed (round == 1 detected)
+        #    ], player1_bet)
+
+        # player 1 make express to events 5, 6, 7 - home win
+        player1_bet = 200
+        player1_total_bet = player1_total_bet + player1_bet
+        # 26051 - it is early calculated effective odds for this parlay bet
+        player1_expected_win = Decimal(player1_bet * 26051) / ODDS_DIVISOR
+        self.nodes[2].placeparlaybet([{'eventId': 5, 'outcome': outcome_home_win}, {'eventId': 6, 'outcome': outcome_home_win}, {'eventId': 7, 'outcome': outcome_home_win}], player1_bet)
+
+        # player 2 make express to events 5, 6, 7 - home win
+        player2_bet = 500
+        player2_total_bet = player2_total_bet + player2_bet
+        # 26051 - it is early calculated effective odds for this parlay bet
+        player2_expected_win = Decimal(player2_bet * 26051) / ODDS_DIVISOR
+        self.nodes[3].placeparlaybet([{'eventId': 5, 'outcome': outcome_home_win}, {'eventId': 6, 'outcome': outcome_home_win}, {'eventId': 7, 'outcome': outcome_home_win}], player2_bet)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(5))
+        liability=self.nodes[0].geteventliability(5)
+        gotliability=liability["moneyline-home-bets"]
+        assert_equal(gotliability, Decimal(2))
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(6))
+        liability=self.nodes[0].geteventliability(6)
+        gotliability=liability["moneyline-home-bets"]
+        assert_equal(gotliability, Decimal(2))
+        #pprint.pprint(self.nodes[0].geteventliability(7))
+        liability=self.nodes[0].geteventliability(7)
+        gotliability=liability["moneyline-home-bets"]
+        assert_equal(gotliability, Decimal(2))
+
+
+        # place result for event 4: Astralis wins with score 16:9
+        result_opcode = make_result(5, STANDARD_RESULT, 16, 9)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+        # place result for event 5: Astralis wins with score 16:14
+        result_opcode = make_result(6, STANDARD_RESULT, 16, 14)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+        # place result for event 6: Barcelona wins with score 3:2
+        result_opcode = make_result(7, STANDARD_RESULT, 3, 2)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+        self.sync_all()
+        #print("Player 1 Total Bet", player1_total_bet)
+        #print("Player 2 Total Bet", player2_total_bet)
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+
+        check_bet_payouts_info(listbets, payoutsInfo)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        self.log.info("Parlay Bets Success")
+
+    def check_mempool_accept(self):
+        self.log.info("Check Mempool Accepting")
+        # bets to resulted events shouldn't accepted to memory pool after parlay starting height
+        #assert_raises_rpc_error(-4, "Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.", self.nodes[2].placebet, 3, outcome_away_win, 1000)
+        # bets to nonexistent events shouldn't accepted to memory pool
+        #assert_raises_rpc_error(-131, "Error: there is no such Event: {}".format(800), self.nodes[3].placeparlaybet, [{'eventId': 7, 'outcome': outcome_home_win}, {'eventId': 800, 'outcome': outcome_home_win}, {'eventId': 9, 'outcome': outcome_home_win}], 5000)
+
+        # creating existed mapping
+        mapping_opcode = make_mapping(TEAM_MAPPING, 0, "anotherTeamName")
+        assert_raises_rpc_error(-25, "", post_opcode, self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # creating exited event shouldn't accepted to memory pool
+        test_event = make_event(0, # Event ID
+                            self.start_time, # start time = current + hour
+                            sport_names.index("Football"), # Sport ID
+                            tournament_names.index("UEFA Champions League"), # Tournament ID
+                            round_names.index("round2"), # Round ID
+                            team_names.index("Barcelona"), # Home Team
+                            team_names.index("Real Madrid"), # Away Team
+                            14000, # home odds
+                            33000, # away odds
+                            0) # draw odds
+        assert_raises_rpc_error(-25, "", post_opcode, self.nodes[1], test_event, WGR_WALLET_EVENT['addr'])
+
+        # creating result for resulted event shouldn't accepted to memory pool
+        result_opcode = make_result(4, STANDARD_RESULT, 1, 1)
+        assert_raises_rpc_error(-25, "", post_opcode, self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        # creating totals for not existed event shouldn't accepted to memory pool
+        totals_event_opcode = make_total_event(1000, 26, 21000, 23000)
+        assert_raises_rpc_error(-25, "", post_opcode, self.nodes[1], totals_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.log.info("Mempool Accepting Success")
+
+    def check_timecut_refund(self):
+        self.log.info("Check Timecut Refund...")
+
+        global player1_total_bet
+        global player2_total_bet
+
+        # add new event with time = 2 mins to go
+        self.start_time = int(time.time() + 60 * 2)
+        # 8: CSGO - PGL Major Krakow - Astralis vs Gambit round3
+        mlevent = make_event(8, # Event ID
+                            self.start_time, # start time = current + 2 mins
+                            sport_names.index("CSGO"), # Sport ID
+                            tournament_names.index("PGL Major Krakow"), # Tournament ID
+                            round_names.index("round3"), # Round ID
+                            team_names.index("Gambit"), # Home Team
+                            team_names.index("Astralis"), # Away Team
+                            34000, # home odds
+                            14000, # away odds
+                            0) # draw odds
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        # player 1 bet to Team Gambit with odds 34000 but bet will be refunded
+        player1_bet = 1000
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(8, outcome_home_win, player1_bet)
+        winnings = Decimal(player1_bet * ODDS_DIVISOR)
+        player1_expected_win = (winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        # place result for event 7: Gambit wins with score 16:14
+        result_opcode = make_result(8, STANDARD_RESULT, 160, 140)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+
+        listbets = self.nodes[0].listbetsdb(False)
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+        height = block['height']
+
+        self.sync_all()
+        #print("Player 1 Total Bet", player1_total_bet)
+        #print("Player 2 Total Bet", player2_total_bet)
+
+        payoutsInfo = self.nodes[0].getpayoutinfosince(1)
+
+        check_bet_payouts_info(listbets, payoutsInfo)
+
+        #player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player1_balance_after = self.nodes[2].getwalletinfo()['balance'] + self.nodes[2].getwalletinfo()['immature_balance']
+        assert_equal(player1_balance_before + player1_expected_win + 2256, player1_balance_after)
+
+        # return back
+        self.start_time = int(time.time() + 60 * 60)
+
+        self.log.info("Timecut Refund Success")
+
+    def check_asian_spreads_bet(self):
+        self.log.info("Check Asian Spread Bets...")
+
+        global player1_total_bet
+        global player2_total_bet
+
+        # make new event, expected result is 1:0
+        mlevent = make_event(9, # Event ID
+                    self.start_time, # start time = current + hour
+                    sport_names.index("Test Sport"), # Sport ID
+                    tournament_names.index("Test Tournament"), # Tournament ID
+                    round_names.index("round1"), # Round ID
+                    team_names.index("Test Team1"), # Home Team
+                    team_names.index("Test Team2"), # Away Team
+                    15000, # home odds
+                    18000, # away odds
+                    13000) # draw odds
+
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # create asian spread event
+        spread_event_opcode = make_spread_event(9, -125, 14000, 26000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # place spread bet to spread home
+        # in our result it mean 50% bet lose, 50% bet refund
+        player1_bet = 400
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(9, outcome_spread_home, player1_bet)
+        winnings = Decimal(player1_bet * 0.5 * ODDS_DIVISOR)
+        player1_expected_win = winnings / ODDS_DIVISOR
+
+        # change spread condition for event
+        spread_event_opcode = make_spread_event(9, -75, 13000, 27000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        player2_bet = 600
+        player2_total_bet = player2_total_bet + player2_bet
+        # place spread bet to spread away
+        # in our result it mean 50% bet lose, 50% bet refund
+        self.nodes[3].placebet(9, outcome_spread_away, player2_bet)
+        winnings = Decimal(player2_bet * 0.5 * ODDS_DIVISOR)
+        player2_expected_win = winnings / ODDS_DIVISOR
+
+        #self.log.info("Event Liability")
+        #pprint.pprint(self.nodes[0].geteventliability(9))
+        liability=self.nodes[0].geteventliability(9)
+        gotliability=liability["spread-home-liability"]
+        assert_equal(gotliability, Decimal(550))
+        gotliability=liability["spread-push-liability"]
+        assert_equal(gotliability, Decimal(400))
+
+        # place result for event 9:
+        result_opcode = make_result(9, STANDARD_RESULT, 100, 0)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+
+        self.sync_all()
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        self.log.info("Asian Spread Bets Success")
+
+
+    #
+    def check_v2_v3_bet(self):
+        self.log.info("Check V2 to V3 Bets...")
+        # generate so we get to block 300 after event creation & first round bets but before payout sent
+        # change this number to change where generate block 300 takes place generate(26) is block 301 for payout
+        self.nodes[0].generate(26)
+        player1_expected_win = 0
+        player2_expected_win = 0
+        global player1_total_bet
+        global player2_total_bet
+
+        # make new event, expected result is 1:0
+        self.odds_events = []
+        mlevent = make_event(10, # Event ID
+                    self.start_time, # start time = current + hour
+                    sport_names.index("V2-V3 Sport"), # Sport ID
+                    tournament_names.index("V2-V3 Tournament"), # Tournament ID
+                    round_names.index("round1"), # Round ID
+                    team_names.index("V2-V3 Team1"), # Home Team
+                    team_names.index("V2-V3 Team2"), # Away Team
+                    15000, # home odds
+                    18000, # away odds
+                    13000) # draw odds
+        self.odds_events.append({'homeOdds': 15000, 'awayOdds': 18000, 'drawOdds': 13000})
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # create spread event
+        spread_event_opcode = make_spread_event(10, -125, 14000, 26000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        # create totals
+        totals_event_opcode = make_total_event(10, 26, 21000, 23000)
+        post_opcode(self.nodes[1], totals_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        #self.log.info("Events")
+        #pprint.pprint(self.nodes[1].listevents())
+
+        #events_before=self.nodes[0].listevents()
+        #pprint.pprint(events_before[10])
+
+        # Place Bet to ML Home Win
+        player1_bet = 100
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_home_win, player1_bet)
+        winnings = Decimal(player1_bet * self.odds_events[0]['homeOdds'])
+        player1_expected_win = player1_expected_win + ((winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR)
+
+        # Place bet for total over win
+        player1_bet = 200
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_total_over, player1_bet)
+        winnings = Decimal(player1_bet * 21000)
+        player1_expected_win = player1_expected_win + ((winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR)
+
+        # place spread bet to spread home
+        # in our result it mean 50% bet lose, 50% bet refund
+        player1_bet = 400
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_spread_home, player1_bet)
+        winnings = Decimal(player1_bet * 0.5 * ODDS_DIVISOR)
+        player1_expected_win = player1_expected_win + (winnings / ODDS_DIVISOR)
+
+        # change spread condition for event 10
+        spread_event_opcode = make_spread_event(10, -75, 13000, 27000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.log.info("Events before odds updating")
+        pprint.pprint(self.nodes[0].listevents())
+
+        # change odds for ML bet
+        event_id = tournament_names.index("V2-V3 Tournament")
+        self.log.info("Event %s" % event_id)
+        pprint.pprint(self.odds_events)
+        self.odds_events[0]['homeOdds'] = 14000
+        self.odds_events[0]['awayOdds'] = 25000
+        self.odds_events[0]['drawOdds'] = 31000
+        update_odds_opcode = make_update_ml_odds(10,
+                                                self.odds_events[0]['homeOdds'],
+                                                self.odds_events[0]['awayOdds'],
+                                                self.odds_events[0]['drawOdds'])
+        post_opcode(self.nodes[1], update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        #self.odds_events.append({'homeOdds': 14000, 'awayOdds': 25000, 'drawOdds': 31000})
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+        self.log.info("Events after updating")
+
+        # Place Bet to ML Home Win
+        player1_bet = 150
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_home_win, player1_bet)
+        winnings = Decimal(player1_bet * self.odds_events[0]['homeOdds'])
+
+        player1_expected_win = player1_expected_win + ((winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        #should be block height 300
+        self.log.info("Block Height %s" % self.nodes[0].getblockcount())
+        player1_bet = 300
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_spread_away, player1_bet)
+        winnings = Decimal(player1_bet * 0.5 * ODDS_DIVISOR)
+        player1_expected_win = player1_expected_win + (winnings / ODDS_DIVISOR)
+
+        player2_bet = 600
+        player2_total_bet = player2_total_bet + player2_bet
+        # place spread bet to spread away
+        # in our result it mean 50% bet lose, 50% bet refund
+        self.nodes[3].placebet(10, outcome_spread_away, player2_bet)
+        winnings = Decimal(player2_bet * 0.5 * ODDS_DIVISOR)
+        player2_expected_win = player2_expected_win + (winnings / ODDS_DIVISOR)
+
+        # change odds for ML bet
+        event_id = tournament_names.index("V2-V3 Tournament")
+        self.log.info("Event %s" % event_id)
+        pprint.pprint(self.odds_events)
+        self.odds_events[0]['homeOdds'] = 16000
+        self.odds_events[0]['awayOdds'] = 22000
+        self.odds_events[0]['drawOdds'] = 41000
+        update_odds_opcode = make_update_ml_odds(10,
+                                                self.odds_events[0]['homeOdds'],
+                                                self.odds_events[0]['awayOdds'],
+                                                self.odds_events[0]['drawOdds'])
+        post_opcode(self.nodes[1], update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        # Update totals odds
+        totals_event_opcode = make_total_event(10, 26, 26000, 24000)
+        post_opcode(self.nodes[1], totals_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        # Change spread event odds
+        spread_event_opcode = make_spread_event(10, -22, 15000, 22000)
+        post_opcode(self.nodes[1], spread_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Place bet for total over win
+        player2_bet = 300
+        player2_total_bet = player2_total_bet + player2_bet
+        self.nodes[3].placebet(10, outcome_total_over, player2_bet)
+        winnings = Decimal(player2_bet * 26000)
+        player2_expected_win = player2_expected_win + ((winnings - ((winnings - player2_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR)
+
+        # Place Bet to ML Home Win
+        player1_bet = 225
+        player1_total_bet = player1_total_bet + player1_bet
+        self.nodes[2].placebet(10, outcome_home_win, player1_bet)
+        winnings = Decimal(player1_bet * self.odds_events[0]['homeOdds'])
+        player1_expected_win = player1_expected_win + ((winnings - ((winnings - player1_bet * ODDS_DIVISOR) / 1000 * BETX_PERMILLE)) / ODDS_DIVISOR)
+
+        ##player2_bet = 400
+        ##player2_total_bet = player2_total_bet + player2_bet
+        # place spread bet to spread away
+        # in our result it mean 50% bet lose, 50% bet refund
+        ##self.nodes[3].placebet(10, outcome_spread_home, player2_bet)
+        ##winnings = Decimal(player2_bet * 0.5 * ODDS_DIVISOR)
+        ##player2_expected_win = player2_expected_win + (winnings / ODDS_DIVISOR)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # place result for event 10
+        result_opcode = make_result(10, STANDARD_RESULT, 100, 0)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(5)
+        self.sync_all()
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before = Decimal(self.nodes[3].getbalance())
+
+        # generate block with payouts
+        blockhash = self.nodes[0].generate(1)[0]
+        block = self.nodes[0].getblock(blockhash)
+
+        self.sync_all()
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_before + player1_expected_win, player1_balance_after)
+        assert_equal(player2_balance_before + player2_expected_win, player2_balance_after)
+
+        self.log.info("V2 to V3 Bets Success")
+
+    def check_bets(self):
+        self.log.info("Check Bets")
+        #time.sleep(2000)
+        betam1 = 0
+        betpay1 = 0
+        betam2 = 0
+        betpay2 = 0
+        for bets in range(self.num_nodes):
+            if bets == 0:
+                mybets=self.nodes[bets].getmybets()
+                #self.log.info("Bets Node %d" % bets)
+                assert_equal(mybets, [])
+            elif bets == 1:
+                mybets=self.nodes[bets].getmybets()
+                #self.log.info("Bets Node %d" % bets)
+                assert_equal(mybets, [])
+            elif bets == 2:
+                mybets=self.nodes[bets].getmybets("Node2Addr", 100)
+                #self.log.info("Bets Node %d" % bets)
+                #self.log.info("Bet length %d" % len(mybets))
+                for bet in range(len(mybets)):
+                    #self.log.info("Bet Result %s " % mybets[bet]['betResultType'])
+                    betam1 = betam1 + mybets[bet]['amount']
+                    #self.log.info("Bet Amount %d " % mybets[bet]['amount'])
+                    #self.log.info("Bet Payout %d " % mybets[bet]['payout'])
+                    betpay1 = betpay1 + mybets[bet]['payout']
+            elif bets == 3:
+                mybets=self.nodes[bets].getmybets("Node3Addr", 100)
+                #self.log.info("Bets Node %d" % bets)
+                #self.log.info("Bet length %d" % len(mybets))
+                for bet in range(len(mybets)):
+                    #self.log.info("Bet Result %s " % mybets[bet]['betResultType'])
+                    #self.log.info("Bet Amount %d " % mybets[bet]['amount'])
+                    betam2 = betam2 + mybets[bet]['amount']
+                    #self.log.info("Bet Payout %d " % mybets[bet]['payout'])
+                    betpay2 = betpay2 + mybets[bet]['payout']
+            else:
+                self.log.info("Too Many Nodes")
+
+        #self.log.info("Total Amount Bet Player 1 %s" % player1_total_bet)
+        assert_equal(betam1, player1_total_bet + 300)
+        #self.log.info("Total Amount Won Player 1 %s" % betpay1)
+        assert_equal(round(Decimal(betpay1), 8), round(Decimal(4934.2200000), 8))
+        #self.log.info("Total Amount Bet Player 2 %s" % player2_total_bet)
+        assert_equal(betam2, player2_total_bet + 350)
+        #self.log.info("Total Amount Won Player 2 %s" % betpay2)
+        assert_equal(round(Decimal(betpay2), 8), round(Decimal(3546.3500000), 8))
+
+        self.log.info("Debug Events")
+        pprint.pprint(self.nodes[0].listeventsdebug())
+        self.log.info("All Bets")
+        allbets=self.nodes[0].getallbets()
+        #pprint.pprint(len(allbets))
+        bettxid=allbets[0]["betTxHash"]
+
+        self.log.info("Bet 0 by getbet")
+        bet0=self.nodes[0].getbet(bettxid, True)
+        pprint.pprint(bet0)
+        self.log.info("Bet 0 by getbetbytxid")
+        bet1=self.nodes[0].getbetbytxid(bettxid)
+        pprint.pprint(bet1)
+        assert_equal(bet0["amount"], bet1[0]["amount"])
+        assert_equal(bet0["result"], bet1[0]["betResultType"])
+        assert_equal(bet0["tx-id"], bet1[0]["betTxHash"])
+
+        #time.sleep(2000)
+        ###
+        ## Not working TODO Fix it
+        ###
+        #self.log.info("Get Payout Info")
+        #payinfo={"txhash":bettxid, "nOut":1}
+        #pprint.pprint(self.nodes[0].getpayoutinfo([payinfo]))
+
+        self.log.info("Check Bets Success")
+
+    def check_zero_odds_bet(self):
+        self.log.info("Check Zero Odds Bets...")
+
+        event_id = 12
+        mlevent = make_event(12, # Event ID
+                    int(time.time()) + 60*60, # start time = current + hour
+                    sport_names.index("V2-V3 Sport"), # Sport ID
+                    tournament_names.index("V2-V3 Tournament"), # Tournament ID
+                    round_names.index("round1"), # Round ID
+                    team_names.index("V2-V3 Team1"), # Home Team
+                    team_names.index("V2-V3 Team2"), # Away Team
+                    16000, # home odds
+                    0, # away odds
+                    80000) # draw odds
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        # Need to be at betting V4 for this
+        self.nodes[0].generate(86)
+
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_away_win),
+            self.nodes[1].placebet, event_id, outcome_away_win, 100)
+
+        self.nodes[2].placebet(event_id, outcome_home_win, 25)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_away_win),
+            self.nodes[1].placeparlaybet, [{'eventId':event_id, 'outcome': outcome_away_win}], 100)
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_away_win),
+            self.nodes[1].placeparlaybet, [{'eventId': 2, 'outcome': outcome_home_win}, {'eventId':event_id, 'outcome': outcome_away_win}], 100)
+
+        self.nodes[2].placeparlaybet([{'eventId':event_id, 'outcome': outcome_home_win}], 25)
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        homeOdds = 0
+        awayOdds = 0
+        drawOdds = 0
+        update_odds_opcode = make_update_ml_odds(event_id,
+                                                homeOdds,
+                                                awayOdds,
+                                                drawOdds)
+        post_opcode(self.nodes[1], update_odds_opcode, WGR_WALLET_EVENT['addr'])
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_away_win),
+            self.nodes[1].placebet, event_id, outcome_away_win, 100)
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_home_win),
+            self.nodes[1].placebet, event_id, outcome_home_win, 100)
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_draw),
+            self.nodes[1].placebet, event_id, outcome_draw, 100)
+
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_away_win),
+            self.nodes[1].placeparlaybet, [{'eventId': 2, 'outcome': outcome_home_win}, {'eventId':event_id, 'outcome': outcome_away_win}], 100)
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_home_win),
+            self.nodes[1].placeparlaybet, [{'eventId': 2, 'outcome': outcome_home_win}, {'eventId':event_id, 'outcome': outcome_home_win}], 100)
+        assert_raises_rpc_error(-131, "Error: potential odds is zero for event: {} outcome: {}".format(event_id, outcome_draw),
+            self.nodes[1].placeparlaybet, [{'eventId': 2, 'outcome': outcome_home_win}, {'eventId':event_id, 'outcome': outcome_draw}], 100)
+
+        self.log.info("Check Zero Odds Bets Success")
+
+    def check_zeroing_odds(self):
+        self.log.info("Check zeroing odds...")
+        self.log.info("Generate to Protocol V4 start height")
+        self.nodes[0].generate(27)
+        saved_events = {}
+        for i, node in enumerate(self.nodes):
+            saved_events[i] = {}
+            for event in node.listevents():
+                saved_events[i][event['event_id']] = event
+
+        self.stop_node(3)
+
+        for i, node in enumerate(self.nodes[:3]):
+            for event in node.listevents():
+                # 0 mean ml odds in odds array
+                assert_equal(event['odds'][0]['mlHome'], saved_events[i][event['event_id']]['odds'][0]['mlHome'])
+                assert_equal(event['odds'][0]['mlAway'], saved_events[i][event['event_id']]['odds'][0]['mlAway'])
+                assert_equal(event['odds'][0]['mlDraw'], saved_events[i][event['event_id']]['odds'][0]['mlDraw'])
+                # 1 mean spreads odds in odds array
+                assert_equal(event['odds'][1]['spreadHome'], saved_events[i][event['event_id']]['odds'][1]['spreadHome'])
+                assert_equal(event['odds'][1]['spreadAway'], saved_events[i][event['event_id']]['odds'][1]['spreadAway'])
+                # 2 mean totals odds in odds array
+                assert_equal(event['odds'][2]['totalsOver'],  saved_events[i][event['event_id']]['odds'][2]['totalsOver'])
+                assert_equal(event['odds'][2]['totalsUnder'], saved_events[i][event['event_id']]['odds'][2]['totalsUnder'])
+
+        event_ids = []
+        for event in self.nodes[0].listevents():
+            event_ids.append(event['event_id'])
+
+        zeroing_odds_opcode = make_zeroing_odds(event_ids)
+        post_opcode(self.nodes[1], zeroing_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.sync_all(self.nodes[:3])
+        self.nodes[0].generate(1)
+        self.sync_all(self.nodes[:3])
+
+        for node in self.nodes[:3]:
+            for event in node.listevents():
+                # 0 mean ml odds in odds array
+                assert_equal(event['odds'][0]['mlHome'], 0)
+                assert_equal(event['odds'][0]['mlAway'], 0)
+                assert_equal(event['odds'][0]['mlDraw'], 0)
+                # 1 mean spreads odds in odds array
+                assert_equal(event['odds'][1]['spreadHome'], 0)
+                assert_equal(event['odds'][1]['spreadAway'], 0)
+                # 2 mean totals odds in odds array
+                assert_equal(event['odds'][2]['totalsOver'], 0)
+                assert_equal(event['odds'][2]['totalsUnder'], 0)
+
+        self.log.info("Reverting...")
+        self.nodes[3].rpchost = self.get_local_peer(3, True)
+        self.nodes[3].start()
+        self.nodes[3].wait_for_rpc_connection()
+
+        self.log.info("Generate blocks...")
+        for i in range(5):
+            self.nodes[3].generate(1)
+
+        for event in self.nodes[3].listevents():
+            # 0 mean ml odds in odds array
+            assert_equal(event['odds'][0]['mlHome'], saved_events[3][event['event_id']]['odds'][0]['mlHome'])
+            assert_equal(event['odds'][0]['mlAway'], saved_events[3][event['event_id']]['odds'][0]['mlAway'])
+            assert_equal(event['odds'][0]['mlDraw'], saved_events[3][event['event_id']]['odds'][0]['mlDraw'])
+            # 1 mean spreads odds in odds array
+            assert_equal(event['odds'][1]['spreadHome'], saved_events[3][event['event_id']]['odds'][1]['spreadHome'])
+            assert_equal(event['odds'][1]['spreadAway'], saved_events[3][event['event_id']]['odds'][1]['spreadAway'])
+            # 2 mean totals odds in odds array
+            assert_equal(event['odds'][2]['totalsOver'],  saved_events[3][event['event_id']]['odds'][2]['totalsOver'])
+            assert_equal(event['odds'][2]['totalsUnder'], saved_events[3][event['event_id']]['odds'][2]['totalsUnder'])
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        for i, node in enumerate(self.nodes):
+            for event in node.listevents():
+                assert_equal(event['odds'][0]['mlHome'], saved_events[i][event['event_id']]['odds'][0]['mlHome'])
+                assert_equal(event['odds'][0]['mlAway'], saved_events[i][event['event_id']]['odds'][0]['mlAway'])
+                assert_equal(event['odds'][0]['mlDraw'], saved_events[i][event['event_id']]['odds'][0]['mlDraw'])
+                # 1 mean spreads odds in odds array
+                assert_equal(event['odds'][1]['spreadHome'], saved_events[i][event['event_id']]['odds'][1]['spreadHome'])
+                assert_equal(event['odds'][1]['spreadAway'], saved_events[i][event['event_id']]['odds'][1]['spreadAway'])
+                # 2 mean totals odds in odds array
+                assert_equal(event['odds'][2]['totalsOver'],  saved_events[i][event['event_id']]['odds'][2]['totalsOver'])
+                assert_equal(event['odds'][2]['totalsUnder'], saved_events[i][event['event_id']]['odds'][2]['totalsUnder'])
+
+        self.log.info("Check zeroing odds Success")
+
+    def check_closing_event(self):
+
+        self.log.info("Check closing event opcode...")
+
+        event_id = 82
+        mlevent = make_event(event_id, # Event ID
+                    int(time.time()) + 60*60, # start time = current + hour
+                    sport_names.index("V2-V3 Sport"), # Sport ID
+                    tournament_names.index("V2-V3 Tournament"), # Tournament ID
+                    round_names.index("round1"), # Round ID
+                    team_names.index("V2-V3 Team1"), # Home Team
+                    team_names.index("V2-V3 Team2"), # Away Team
+                    16000, # home odds
+                    20000, # away odds
+                    80000) # draw odds
+        post_opcode(self.nodes[1], mlevent, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+        #breakpoint()
+        time.sleep(10)
+        self.nodes[0].generate(1)
+        self.nodes[2].placebet(event_id, outcome_home_win, 25)
+
+        self.sync_all()
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        player1_balance = self.nodes[2].getbalance()
+
+        # get opened events only
+        opened_events = self.nodes[0].listevents(True)
+
+        start_height = self.nodes[3].getblockcount()
+
+        # stop node fo reventing
+        self.stop_node(3)
+
+        # close all events
+        for event in opened_events:
+            result_opcode = make_result(event['event_id'], EVENT_CLOSED, 0, 0)
+            post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(5)
+        self.sync_all(self.nodes[:3])
+        self.nodes[0].generate(5)
+        self.sync_all(self.nodes[:3])
+
+        assert_equal(len(self.nodes[0].listevents(True)), 0)
+        assert_equal(player1_balance, self.nodes[2].getbalance())
+
+        blocks = self.nodes[1].getblockcount() - start_height + 1
+
+        self.nodes[3].rpchost = self.get_local_peer(3, True)
+        self.nodes[3].start()
+        self.nodes[3].wait_for_rpc_connection()
+
+        self.log.info("Generate blocks...")
+        self.nodes[3].generate(blocks)
+        self.connect_and_sync_blocks()
+
+        assert_equal(self.nodes[0].listevents(True), opened_events)
+
+        self.log.info("Check closing event Success")
+
+    def run_test(self):
+        self.check_minting()
+        # Chain height = 300 after minting -> v4 protocol active
+        self.check_mapping()
+        self.check_event()
+        self.check_event_patch()
+        self.check_update_odds()
+        self.check_spread_event()
+        self.check_spread_event_v2()
+        self.check_total_event()
+        self.check_ml_bet()
+        # disable check spreads bets v1, becouse new spread system
+        # uses spreads v1 before wagerr v3 prot, but regtest uses wagerr v3 prot
+        # since first PoS block and we always have wagerr v3 prot
+        # self.check_spreads_bet()
+        self.check_totals_bet()
+        # Chain Games are discontinued
+        # self.check_chain_games()
+        # not neeeded anymore
+        # self.check_v2_v3_bet()
+        self.check_spreads_bet_v2()
+        self.check_parlays_bet()
+        self.check_mempool_accept()
+        self.check_timecut_refund() # Not working TODO fix it
+        self.check_asian_spreads_bet()
+        self.check_bets()
+        self.check_zero_odds_bet()
+        self.check_zeroing_odds()
+        self.check_closing_event()
+
+if __name__ == '__main__':
+    BettingTest().main()

--- a/test/functional/feature_dip3_deterministicmns.py
+++ b/test/functional/feature_dip3_deterministicmns.py
@@ -75,6 +75,13 @@ class DIP3Test(WagerrTestFramework):
 
         # We have hundreds of blocks to sync here, give it more time
         self.log.info("syncing blocks for all nodes")
+        #for n in range(self.num_nodes):
+        #    self.stop_node(n)
+        #    self.start_node(n)
+
+        for n in range(self.num_nodes -1 ):
+            connect_nodes(self.nodes[0], (n+1))
+
         self.sync_blocks(self.nodes, timeout=120)
 
         # DIP3 is fully enforced here

--- a/test/functional/feature_field_betting.py
+++ b/test/functional/feature_field_betting.py
@@ -1,0 +1,1930 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.betting_opcode import *
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import WagerrTestFramework
+from test_framework.util import wait_until, rpc_port, assert_equal, assert_raises_rpc_error, sync_blocks, connect_nodes, disconnect_nodes
+from distutils.dir_util import copy_tree, remove_tree
+from decimal import *
+import pprint
+import time
+import os
+import ctypes
+
+WGR_WALLET_ORACLE = { "addr": "TXuoB9DNEuZx1RCfKw3Hsv7jNUHTt4sVG1", "key": "TBwvXbNNUiq7tDkR2EXiCbPxEJRTxA1i6euNyAE9Ag753w36c1FZ" }
+WGR_WALLET_EVENT = { "addr": "TFvZVYGdrxxNunQLzSnRSC58BSRA7si6zu", "key": "TCDjD2i4e32kx2Fc87bDJKGBedEyG7oZPaZfp7E1PQG29YnvArQ8" }
+WGR_WALLET_DEV = { "addr": "TLuTVND9QbZURHmtuqD5ESECrGuB9jLZTs", "key": "TFCrxaUt3EjHzMGKXeBqA7sfy3iaeihg5yZPSrf9KEyy4PHUMWVe" }
+WGR_WALLET_OMNO = { "addr": "THofaueWReDjeZQZEECiySqV9GP4byP3qr", "key": "TDJnwRkSk8JiopQrB484Ny9gMcL1x7bQUUFFFNwJZmmWA7U79uRk" }
+
+sport_names = ["Sport1", "Horse racing", "F1 racing"]
+round_names = ["round0", "round1",]
+tournament_names = ["Tournament1", "The BMW stakes", "F1 Cup"]
+contender_names = ["cont1", "cont2",
+    "horse1", "horse2", "horse3", "horse4", "horse5",
+    "Alexander Albon", "Daniil Kvyat", "Pierre Gasly", "Romain Grosjean", "Antonio Maria Giovinazzi",
+    "horse6", "horse7", "horse8", "horse9",
+    "cont3", "cont4", "cont5", "cont6", "cont7", "cont8", "cont9"
+]
+
+# Field event groups
+other_group = 1
+animal_racing_group = 2
+
+# Field event market type
+all_markets = 1
+outright_only = 2
+
+# Field bet market types
+market_outright = 1
+market_place    = 2
+market_show     = 3
+
+# Contender result types
+DNF    = 0
+place1 = 1
+place2 = 2
+place3 = 3
+DNR    = 101
+
+def make_odds(probability_percent):
+    if probability_percent == 0:
+        return 0
+    return int((1 / (probability_percent / 100)) * ODDS_DIVISOR)
+
+# Evaluates the probability of the provided player - with index idx1 - arriving amongst the first n
+def eval_prob_in_first(idx, contenders_p, perms):
+    result = 0
+    for perm in perms:
+        if idx not in set(perm):
+            continue
+        cur_probs = [contenders_p[k] for k in perm]
+
+        eval_exact_order = 1
+        for prob in cur_probs:
+            eval_exact_order = eval_exact_order * prob
+
+        den = 1
+        for i in range(len(cur_probs)):
+            q = 1
+            for j in range(i):
+                q = q - cur_probs[j]
+            den = den * q
+
+        result = result + (eval_exact_order / den)
+
+    return result
+
+def calculate_odds(odds_type, contenders_odds, contenders_mods, mrg_in_percent):
+    assert_equal(len(contenders_odds), len(contenders_mods))
+    contenders_out_odds = {}
+    N = len(contenders_odds)
+    perms = []
+    if odds_type == "place":
+        if N < 5:
+            for contender_k in contenders_odds.keys():
+                contenders_out_odds[contender_k] = 0
+            return contenders_out_odds
+
+        multiplier = 2
+
+        for cont_id_i in contenders_odds:
+            for cont_id_j in contenders_odds:
+                if cont_id_i == cont_id_j:
+                    continue
+                perms.append([cont_id_i, cont_id_j])
+
+    elif odds_type == "show":
+        if N < 8:
+            for contender_k in contenders_odds.keys():
+                contenders_out_odds[contender_k] = 0
+            return contenders_out_odds
+
+        multiplier = 3
+
+        for cont_id_i in contenders_odds:
+            for cont_id_j in contenders_odds:
+                if cont_id_j == cont_id_i:
+                    continue
+                for cont_id_k in contenders_odds:
+                    if cont_id_k == cont_id_j:
+                        continue
+                    if cont_id_k == cont_id_i:
+                        continue
+                    perms.append([cont_id_i, cont_id_j, cont_id_k])
+
+    else:
+        raise Exception("Wrong odds type")
+
+    # print(len(perms))
+    # for perm in perms:
+    #     print(perm)
+
+    contenders_p = {}
+    for cont_id, cont_odds in contenders_odds.items():
+        if contenders_odds[cont_id] == 0:
+            continue
+        contenders_p[cont_id] = 1 / (cont_odds / ODDS_DIVISOR)
+
+    # TODO: пропустить нулевые
+    contenders_n_probs = {}
+    for cont_id in contenders_odds.keys():
+        if contenders_odds[cont_id] == 0:
+            continue
+        contenders_n_probs[cont_id] = eval_prob_in_first(cont_id, contenders_p, perms)
+
+    print("contenders_n_probs:")
+    for cont_id in contenders_n_probs:
+        print(cont_id, ":", contenders_n_probs[cont_id])
+
+    contenders_n_odds = {}
+    for cont_id in contenders_n_probs:
+        contenders_n_odds[cont_id] = (1 / contenders_n_probs[cont_id]) * ODDS_DIVISOR
+
+    print("contenders_n_odds:")
+    for cont_id in contenders_n_odds:
+        print(cont_id, ":", contenders_n_odds[cont_id])
+
+    h = 0.000001
+    real_mrg_in = (mrg_in_percent / 100) * multiplier
+
+    # calc m
+    m = 1
+    md = m + h
+    ms = m - h
+    for i in range(1, N):
+        f = 0
+        fd = 0
+        fs = 0
+
+        for cont_k in contenders_n_probs.keys():
+            if contenders_n_probs[cont_k] == 0:
+                continue
+            f += contenders_n_probs[cont_k] ** (m + contenders_mods[cont_k])
+            fd += contenders_n_probs[cont_k] ** (md + contenders_mods[cont_k])
+            fs += contenders_n_probs[cont_k] ** (ms + contenders_mods[cont_k])
+
+        f -= real_mrg_in
+        fd -= real_mrg_in
+        fs -= real_mrg_in
+
+        der = (fd - fs) / h
+
+        m = m - (f / der)
+        md = m + h
+        ms = m - h
+
+    # calc X
+    X = 1
+    Xd = X + h
+    Xs = X - h
+    for i in range(1, N):
+        f = 0
+        fd = 0
+        fs = 0
+
+        for cont_k in contenders_n_odds.keys():
+            if contenders_n_odds[cont_k] == 0:
+                continue
+            f += 1 / (1 + (X + contenders_mods[cont_k]) * (contenders_n_odds[cont_k] / ODDS_DIVISOR - 1))
+            fd += 1 / (1 + (Xd + contenders_mods[cont_k]) * (contenders_n_odds[cont_k] / ODDS_DIVISOR - 1))
+            fs += 1 / (1 + (Xs + contenders_mods[cont_k]) * (contenders_n_odds[cont_k] / ODDS_DIVISOR - 1))
+
+        f -= real_mrg_in
+        fd -= real_mrg_in
+        fs -= real_mrg_in
+
+        der = (fd - fs) / h
+
+        X = X - (f / der)
+        Xd = X + h
+        Xs = X - h
+
+    print("odds_type = ", odds_type)
+    print("N = ", N)
+    print("real_mrg_in = ", real_mrg_in)
+    print("m = ", m)
+    print("X = ", X)
+
+    for cont_k in contenders_n_odds.keys():
+        if contenders_n_odds[cont_k] == 0:
+            contenders_out_odds[cont_k] = 0
+            continue
+        odds_x = 1 + (X + contenders_mods[cont_k]) * (contenders_n_odds[cont_k] / ODDS_DIVISOR - 1)
+        odds_m = contenders_n_probs[cont_k] ** (-m - contenders_mods[cont_k])
+        contenders_out_odds[cont_k] = int(((odds_x + odds_m) / 2) * ODDS_DIVISOR)
+
+    return contenders_out_odds
+
+def check_calculate_odds():
+    # contenders_odds = {
+    #     1 : 36699,
+    #     2 : 26152,
+    #     3 : 17617,
+    #     4 : 158265,
+    #     5 : 93296,
+    #     6 : 93296,
+    #     7 : 158265,
+    #     8 : 60873,
+    #     9 : 36699,
+    # }
+    # contenders_odds = {
+    #     2 : 0,
+    #     3 : 0,
+    #     4 : 0,
+    #     5 : 0,
+    #     6 : 0,
+    #     12 : 0,
+    #     13 : 0,
+    #     14 : 0,
+    # }
+    contenders_odds = { # real odds
+        1 : 77047,
+        2 : 51588,
+        3 : 30147,
+        4 : 393762,
+        5 : 219895,
+        6 : 219895,
+        7 : 393762,
+        8 : 136769,
+        9 : 77047,
+    }
+    contenders_mods = {
+        1 : 0,
+        2 : 0,
+        3 : 0,
+        4 : 0,
+        5 : 0,
+        6 : 0,
+        7 : 0,
+        8 : 0,
+        9 : 0,
+    }
+    mrg_in_percent = 115
+
+    out_odds = calculate_odds("place", contenders_odds, contenders_mods, mrg_in_percent)
+    for k in contenders_odds.keys():
+        print(out_odds[k])
+
+    out_odds = calculate_odds("show", contenders_odds, contenders_mods, mrg_in_percent)
+    for k in contenders_odds.keys():
+        print(out_odds[k])
+
+def check_bet_payouts_info(listbets, listpayoutsinfo):
+    for bet in listbets:
+        info_found = False
+        for info in listpayoutsinfo:
+            info_type = info['payoutInfo']['payoutType']
+            if info_type == 'Betting Payout' or info_type == 'Betting Refund':
+                if info['payoutInfo']['betBlockHeight'] == bet['betBlockHeight']:
+                    if info['payoutInfo']['betTxHash'] == bet['betTxHash']:
+                        if info['payoutInfo']['betTxOut'] == bet['betTxOut']:
+                            info_found = True
+        assert(info_found)
+
+class BettingTest(WagerrTestFramework):
+    def get_node_setting(self, node_index, setting_name):
+        with open(os.path.join(self.nodes[node_index].datadir, "wagerr.conf"), 'r', encoding='utf8') as f:
+            for line in f:
+                if line.startswith(setting_name + "="):
+                    return line.split("=")[1].strip("\n")
+        return None
+
+    def get_local_peer(self, node_index, is_rpc=False):
+        port = self.get_node_setting(node_index, "rpcport" if is_rpc else "port")
+        return "127.0.0.1:" + str(rpc_port(node_index) if port is None else port)
+
+    def set_test_params(self):
+        # 0 - main node
+        # 1 - oracle
+        # 2 - player1
+        # 3 - player2
+        # 4 - revert testing
+        self.num_nodes = 5
+        self.extra_args = [[] for n in range(self.num_nodes)]
+        self.setup_clean_chain = True
+        self.players = []
+        # { event_id : { contender_id : odds, ... } }
+        self.mrg_in_percent = 11500 # 115.00%
+
+    def connect_network(self):
+        for i in range(len(self.nodes)):
+            for j in range(len(self.nodes)):
+                if i == j:
+                    continue
+                self.nodes[i].addnode(self.get_local_peer(j), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[i].getpeerinfo()))
+        self.sync_all()
+        for n in range(self.num_nodes):
+            idx_l = n
+            idx_r = n + 1 if n + 1 < self.num_nodes else 0
+            assert_equal(self.nodes[idx_l].getblockcount(), self.nodes[idx_r].getblockcount())
+
+    def connect_and_sync_blocks(self):
+        for i in range(self.num_nodes):
+            for j in range(self.num_nodes):
+                if i == j:
+                    continue
+                self.nodes[i].addnode(self.get_local_peer(j), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[i].getpeerinfo()))
+        sync_blocks(self.nodes)
+
+    def setup_network(self):
+        self.log.info("Setup Network")
+        self.setup_nodes()
+        self.connect_network()
+
+    def check_minting(self, block_count=250):
+        self.log.info("Check Minting...")
+
+        self.nodes[1].importprivkey(WGR_WALLET_ORACLE['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_EVENT['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_DEV['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_OMNO['key'])
+
+        self.players.append(self.nodes[2].getnewaddress('Node2Addr'))
+        self.players.append(self.nodes[3].getnewaddress('Node3Addr'))
+        node4Addr = self.nodes[4].getnewaddress('Node4Addr')
+        self.log.info("node4Addr = " + str(node4Addr))
+        self.log.info("player1 addr = " + str(self.players[0]))
+        self.log.info("player2 addr = " + str(self.players[1]))
+
+        for i in range(block_count - 1):
+            blocks = self.nodes[0].generate(1)
+            blockinfo = self.nodes[0].getblock(blocks[0])
+            # get coinbase tx
+            rawTx = self.nodes[0].getrawtransaction(blockinfo['tx'][0])
+            decodedTx = self.nodes[0].decoderawtransaction(rawTx)
+            address = decodedTx['vout'][0]['scriptPubKey']['addresses'][0]
+            #if (i > 0):
+                # minting must process to sigle address
+                #assert_equal(address, prevAddr)
+            prevAddr = address
+
+        for i in range(30):
+            self.nodes[0].sendtoaddress(WGR_WALLET_ORACLE['addr'], 2000)
+            self.nodes[0].sendtoaddress(WGR_WALLET_EVENT['addr'], 2000)
+            self.nodes[0].sendtoaddress(self.players[0], 2000)
+            self.nodes[0].sendtoaddress(self.players[1], 2000)
+
+        for i in range(30):
+            self.nodes[0].sendtoaddress(node4Addr, 2000)
+
+        self.nodes[0].generate(51)
+        for r in range(self.num_nodes):
+            self.stop_node(r)
+            self.start_node(r)
+
+        for n in range(self.num_nodes -1 ):
+            connect_nodes(self.nodes[0], (n+1))
+
+        self.sync_all()
+
+        for n in range(self.num_nodes):
+            assert_equal( self.nodes[n].getblockcount(), 300)
+
+        assert_equal(self.nodes[1].getbalance(), 120000) # oracle
+        assert_equal(self.nodes[2].getbalance(), 60000) # player1
+        assert_equal(self.nodes[3].getbalance(), 60000) # player2
+        assert_equal(self.nodes[4].getbalance(), 60000) # revert node
+
+        self.log.info("Minting Success")
+
+    def check_mapping(self):
+        self.log.info("Check Mapping...")
+
+        self.nodes[0].generate(101)
+        sync_blocks(self.nodes)
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingid, "", "")
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingname, "abc123", 0)
+
+        for id in range(len(sport_names)):
+           mapping_opcode = make_mapping(INDIVIDUAL_SPORT_MAPPING, id, sport_names[id])
+           post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        for id in range(len(round_names)):
+            mapping_opcode = make_mapping(ROUND_MAPPING, id, round_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        for id in range(len(contender_names)):
+            mapping_opcode = make_mapping(CONTENDER_MAPPING, id, contender_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        for id in range(len(tournament_names)):
+            mapping_opcode = make_mapping(TOURNAMENT_MAPPING, id, tournament_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        for node in self.nodes:
+            # Check sports mapping
+            for id in range(len(sport_names)):
+                mapping = node.getmappingname("individualSports", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], sport_names[id])
+                assert_equal(mapping['mapping-type'], "individualSports")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("individualSports", sport_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "individualSports")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check rounds mapping
+            for id in range(len(round_names)):
+                mapping = node.getmappingname("rounds", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], round_names[id])
+                assert_equal(mapping['mapping-type'], "rounds")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("rounds", round_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "rounds")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check teams mapping
+            for id in range(len(contender_names)):
+                mapping = node.getmappingname("contenders", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], contender_names[id])
+                assert_equal(mapping['mapping-type'], "contenders")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("contenders", contender_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "contenders")
+                assert_equal(mappingid['mapping-id'], id)
+
+            # Check tournaments mapping
+            for id in range(len(tournament_names)):
+                mapping = node.getmappingname("tournaments", id)[0]
+                assert_equal(mapping['exists'], True)
+                assert_equal(mapping['mapping-name'], tournament_names[id])
+                assert_equal(mapping['mapping-type'], "tournaments")
+                assert_equal(mapping['mapping-index'], id)
+                mappingid = node.getmappingid("tournaments", tournament_names[id])[0]
+                assert_equal(mappingid['exists'], True)
+                assert_equal(mappingid['mapping-index'], "tournaments")
+                assert_equal(mappingid['mapping-id'], id)
+
+        self.log.info("Mapping Success")
+
+    def check_event(self):
+        self.log.info("Check Event creation...")
+        start_time = int(time.time() + 60 * 60)
+
+        # Bad case
+        field_event_opcode = make_field_event(
+            0,
+            start_time,
+            100, # bad group
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1"): make_odds(10),
+                contender_names.index("cont2"): make_odds(11),
+                contender_names.index("cont3"): make_odds(12),
+                contender_names.index("cont4"): make_odds(13),
+                contender_names.index("cont5"): make_odds(14),
+                contender_names.index("cont6"): make_odds(20),
+                contender_names.index("cont7"): make_odds(15),
+                contender_names.index("cont8"): make_odds(5),
+                contender_names.index("cont9"): make_odds(0)
+            }
+        )
+        assert_raises_rpc_error(-25, "",
+            post_opcode, self.nodes[1], field_event_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # Test revert
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        # CASE: none animal sport group
+        field_event_opcode = make_field_event(
+            0,
+            start_time,
+            other_group,
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1"): make_odds(10),
+                contender_names.index("cont2"): make_odds(11),
+                contender_names.index("cont3"): make_odds(12),
+                contender_names.index("cont4"): make_odds(13),
+                contender_names.index("cont5"): make_odds(14),
+                contender_names.index("cont6"): make_odds(20),
+                contender_names.index("cont7"): make_odds(15),
+                contender_names.index("cont8"): make_odds(5),
+                contender_names.index("cont9"): make_odds(0)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        assert_raises_rpc_error(-25, "",
+            post_opcode, self.nodes[1], field_event_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # pprint.pprint(self.nodes[1].listfieldevents()[0]['contenders'])
+
+        # for node in self.nodes[0:4]:
+        list_events = self.nodes[3].listfieldevents()
+        assert_equal(len(list_events), 1)
+        event_id = list_events[0]['event_id']
+        assert_equal(list_events[0]['sport'], "Sport1")
+        assert_equal(list_events[0]['tournament'], "Tournament1")
+        assert_equal(list_events[0]['round'], "round0")
+        assert_equal(list_events[0]['mrg-in'], self.mrg_in_percent)
+        # assert_equal(len(list_events[0]['contenders']), 9)
+
+        assert_equal(list_events[0]['contenders'][8]['name'], "cont9")
+        assert_equal(list_events[0]['contenders'][8]['input-odds'], 0)
+        assert_equal(list_events[0]['contenders'][8]['outright-odds'], 0)
+        assert_equal(list_events[0]['contenders'][8]['place-odds'], 0)
+        assert_equal(list_events[0]['contenders'][8]['show-odds'], 0)
+
+        assert_equal(list_events[0]['contenders'][0]['name'], "cont1")
+        assert_equal(list_events[0]['contenders'][0]['input-odds'], make_odds(10))
+        assert_equal(list_events[0]['contenders'][0]['outright-odds'], 86387)
+        assert_equal(list_events[0]['contenders'][0]['place-odds'], 41599)
+        assert_equal(list_events[0]['contenders'][0]['show-odds'], 26803)
+
+        assert_equal(list_events[0]['contenders'][1]['name'], "cont2")
+        assert_equal(list_events[0]['contenders'][1]['input-odds'], make_odds(11))
+        assert_equal(list_events[0]['contenders'][1]['outright-odds'], 78670)
+        assert_equal(list_events[0]['contenders'][1]['place-odds'], 38300)
+        assert_equal(list_events[0]['contenders'][1]['show-odds'], 24926)
+
+        assert_equal(list_events[0]['contenders'][5]['name'], "cont6")
+        assert_equal(list_events[0]['contenders'][5]['input-odds'], make_odds(20))
+        assert_equal(list_events[0]['contenders'][5]['outright-odds'], 43949)
+        assert_equal(list_events[0]['contenders'][5]['place-odds'], 23464)
+        assert_equal(list_events[0]['contenders'][5]['show-odds'], 16629)
+
+        # CASE: animal racing sport group
+        field_event_opcode = make_field_event(
+            101,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1"): make_odds(10),
+                contender_names.index("cont2"): make_odds(11),
+                contender_names.index("cont3"): make_odds(12),
+                contender_names.index("cont4"): make_odds(13),
+                contender_names.index("cont5"): make_odds(14),
+                contender_names.index("cont6"): make_odds(20),
+                contender_names.index("cont7"): make_odds(15),
+                contender_names.index("cont8"): make_odds(5),
+                contender_names.index("cont9"): make_odds(0)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # pprint.pprint(self.nodes[1].listfieldevents()[1]['contenders'])
+
+        #for node in self.nodes[0:4]:
+        list_events = self.nodes[3].listfieldevents()
+        assert_equal(len(list_events), 2)
+        event = list_events[1]
+        assert_equal(event['sport'], "Sport1")
+        assert_equal(event['tournament'], "Tournament1")
+        assert_equal(event['round'], "round0")
+        assert_equal(event['mrg-in'], self.mrg_in_percent)
+
+        assert_equal(event['contenders'][8]['name'], "cont9")
+        assert_equal(event['contenders'][8]['outright-odds'], 0)
+        assert_equal(event['contenders'][8]['place-odds'], 0)
+        assert_equal(event['contenders'][8]['show-odds'], 0)
+
+        assert_equal(event['contenders'][0]['name'], "cont1")
+        assert_equal(event['contenders'][0]['input-odds'], make_odds(10))
+        assert_equal(event['contenders'][0]['outright-odds'], 86387)
+        assert_equal(event['contenders'][0]['place-odds'], 40472)
+        assert_equal(event['contenders'][0]['show-odds'], 25843)
+
+        assert_equal(event['contenders'][1]['name'], "cont2")
+        assert_equal(event['contenders'][1]['input-odds'], make_odds(11))
+        assert_equal(event['contenders'][1]['outright-odds'], 78670)
+        assert_equal(event['contenders'][1]['place-odds'], 37687)
+        assert_equal(event['contenders'][1]['show-odds'], 24450)
+
+        assert_equal(event['contenders'][4]['name'], "cont5")
+        assert_equal(event['contenders'][4]['input-odds'], make_odds(14))
+        assert_equal(event['contenders'][4]['outright-odds'], 62136)
+        assert_equal(event['contenders'][4]['place-odds'], 31554)
+        assert_equal(event['contenders'][4]['show-odds'], 21344)
+
+        self.log.info("Revering...")
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        assert_equal(len(self.nodes[4].listfieldevents()), 0)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        for node in self.nodes:
+            assert_equal(len(node.listfieldevents()), 0)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        self.log.info("Event creation Success")
+
+    def check_event_update_odds(self):
+        self.log.info("Check Event Update Odds...")
+        start_time = int(time.time() + 60 * 60)
+
+        for node in self.nodes:
+            assert_equal(len(node.listfieldevents()), 2)
+
+        # Create events
+        field_event_opcode = make_field_event(
+            1,
+            start_time,
+            other_group,
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1") : make_odds(50)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_event_opcode = make_field_event(
+            301,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1") : make_odds(50)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        saved_other_event = {}
+        for node in self.nodes:
+            list_events = node.listfieldevents()
+            assert_equal(len(list_events), 4)
+            for event in list_events:
+                if event['event_id'] == 1:
+                    saved_other_event = event
+                    assert_equal(event['contenders'][0]['name'], "cont1")
+                    assert_equal(event['contenders'][0]['input-odds'], make_odds(50))
+                    assert_equal(event['contenders'][0]['place-odds'], 0)
+                    assert_equal(event['contenders'][0]['show-odds'], 0)
+                if event['event_id'] == 301:
+                    saved_animal_event = event
+                    assert_equal(event['contenders'][0]['name'], "cont1")
+                    assert_equal(event['contenders'][0]['input-odds'], make_odds(50))
+                    assert_equal(event['contenders'][0]['place-odds'], 0)
+                    assert_equal(event['contenders'][0]['show-odds'], 0)
+
+        assert_equal(saved_other_event['event_id'], 1)
+        assert_equal(len(saved_other_event['contenders']), 1)
+        assert_equal(saved_other_event['contenders'][0]['name'], "cont1")
+        assert_equal(saved_other_event['contenders'][0]['input-odds'], make_odds(50))
+        assert_equal(saved_other_event['contenders'][0]['place-odds'], 0)
+        assert_equal(saved_other_event['contenders'][0]['show-odds'], 0)
+
+        assert_equal(saved_animal_event['event_id'], 301)
+        assert_equal(len(saved_animal_event['contenders']), 1)
+        assert_equal(saved_animal_event['contenders'][0]['name'], "cont1")
+        assert_equal(saved_animal_event['contenders'][0]['input-odds'], make_odds(50))
+        assert_equal(saved_animal_event['contenders'][0]['place-odds'], 0)
+        assert_equal(saved_animal_event['contenders'][0]['show-odds'], 0)
+
+        # For revert test
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        field_update_odds_opcode = make_field_update_odds(
+            1,
+            {
+                contender_names.index("cont1") : make_odds(50),
+                100 : 15000 # bad contender_id
+            }
+        )
+        assert_raises_rpc_error(-25, "",
+            post_opcode, self.nodes[1], field_update_odds_opcode, WGR_WALLET_ORACLE['addr'])
+
+        field_update_odds_opcode = make_field_update_odds(
+            100, # bad event_id
+            {
+                contender_names.index("cont1") : make_odds(50)
+            }
+        )
+        assert_raises_rpc_error(-25, "",
+            post_opcode, self.nodes[1], field_update_odds_opcode, WGR_WALLET_ORACLE['addr'])
+
+        # Update odds for events
+        field_update_odds_opcode = make_field_update_odds(
+            1,
+            {
+                contender_names.index("cont1") : make_odds(51)
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_update_odds_opcode = make_field_update_odds(
+            301,
+            {
+                contender_names.index("cont1") : make_odds(51)
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        list_events = self.nodes[1].listfieldevents()
+        assert_equal(len(list_events), 4)
+        for event in list_events:
+            if event['event_id'] == 1:
+                assert_equal(len(event['contenders']), 1)
+                assert_equal(event['contenders'][0]['name'], "cont1")
+                assert_equal(event['contenders'][0]['input-odds'], make_odds(51))
+                assert_equal(event['contenders'][0]['place-odds'], 0)
+                assert_equal(event['contenders'][0]['show-odds'], 0)
+            if event['event_id'] == 301:
+                assert_equal(len(event['contenders']), 1)
+                assert_equal(event['contenders'][0]['name'], "cont1")
+                assert_equal(event['contenders'][0]['input-odds'], make_odds(51))
+                assert_equal(event['contenders'][0]['place-odds'], 0)
+                assert_equal(event['contenders'][0]['show-odds'], 0)
+
+        field_update_odds_opcode = make_field_update_odds(1, {
+                contender_names.index("cont2") : make_odds(49) # Add new conteder
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_update_odds_opcode = make_field_update_odds(301, {
+                contender_names.index("cont2") : make_odds(49) # Add new conteder
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        list_events = self.nodes[2].listfieldevents()
+        assert_equal(len(list_events), 4)
+        for event in list_events:
+            if event['event_id'] == 1:
+                assert_equal(len(event['contenders']), 2)
+                assert_equal(event['contenders'][0]['name'], "cont1")
+                assert_equal(event['contenders'][0]['input-odds'], make_odds(51))
+                assert_equal(event['contenders'][0]['place-odds'], 0)
+                assert_equal(event['contenders'][0]['show-odds'], 0)
+                assert_equal(event['contenders'][1]['name'], "cont2")
+                assert_equal(event['contenders'][1]['input-odds'], make_odds(49))
+                assert_equal(event['contenders'][1]['place-odds'], 0)
+                assert_equal(event['contenders'][1]['show-odds'], 0)
+            if event['event_id'] == 301:
+                assert_equal(len(event['contenders']), 2)
+                assert_equal(event['contenders'][0]['name'], "cont1")
+                assert_equal(event['contenders'][0]['input-odds'], make_odds(51))
+                assert_equal(event['contenders'][0]['place-odds'], 0)
+                assert_equal(event['contenders'][0]['show-odds'], 0)
+                assert_equal(event['contenders'][1]['name'], "cont2")
+                assert_equal(event['contenders'][1]['input-odds'], make_odds(49))
+                assert_equal(event['contenders'][1]['place-odds'], 0)
+                assert_equal(event['contenders'][1]['show-odds'], 0)
+
+        field_update_odds_opcode = make_field_update_odds(1, {
+                contender_names.index("cont2") : make_odds(10),
+                # Add new conteders
+                contender_names.index("horse1") : make_odds(4),
+                contender_names.index("horse2") : make_odds(5),
+                contender_names.index("horse3") : make_odds(5),
+                contender_names.index("horse4") : make_odds(10),
+                contender_names.index("horse5") : make_odds(10),
+                contender_names.index("horse6") : make_odds(5),
+                contender_names.index("horse7") : 0
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_update_odds_opcode = make_field_update_odds(301, {
+                contender_names.index("cont2") : make_odds(10),
+                # Add new conteders
+                contender_names.index("horse1") : make_odds(4),
+                contender_names.index("horse2") : make_odds(5),
+                contender_names.index("horse3") : make_odds(5),
+                contender_names.index("horse4") : make_odds(10),
+                contender_names.index("horse5") : make_odds(10),
+                contender_names.index("horse6") : make_odds(5),
+                contender_names.index("horse7") : 0
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # print(self.nodes[0].listfieldevents()[1]['contenders'])
+
+        #for node in self.nodes[0:4]:
+        list_events = self.nodes[2].listfieldevents()
+        assert_equal(len(list_events), 4)
+        for event in list_events:
+            if event['event_id'] == 1:
+                assert_equal(len(event['contenders']), 9)
+                event_contenders = event['contenders']
+                # pprint.pprint(event_contenders)
+                assert_equal(event_contenders[0]['name'], "cont1")
+                assert_equal(event_contenders[0]['input-odds'], make_odds(51))
+                assert_equal(event_contenders[0]['outright-odds'], 17844)
+                assert_equal(event_contenders[0]['place-odds'], 12298)
+                assert_equal(event_contenders[0]['show-odds'], 10741)
+                assert_equal(event_contenders[2]['name'], "horse1")
+                assert_equal(event_contenders[2]['input-odds'], make_odds(4))
+                assert_equal(event_contenders[2]['outright-odds'], 205958)
+                assert_equal(event_contenders[2]['place-odds'], 77131)
+                assert_equal(event_contenders[2]['show-odds'], 42832)
+                assert_equal(event_contenders[7]['name'], "horse6")
+                assert_equal(event_contenders[7]['input-odds'], make_odds(5))
+                assert_equal(event_contenders[7]['outright-odds'], 165133)
+                assert_equal(event_contenders[7]['place-odds'], 62991)
+                assert_equal(event_contenders[7]['show-odds'], 35564)
+                assert_equal(event_contenders[8]['name'], "horse7")
+                assert_equal(event_contenders[8]['input-odds'], 0)
+                assert_equal(event_contenders[8]['outright-odds'], 0)
+                assert_equal(event_contenders[8]['place-odds'], 0)
+                assert_equal(event_contenders[8]['show-odds'], 0)
+            if event['event_id'] == 301:
+                assert_equal(len(event['contenders']), 9)
+                event_contenders = event['contenders']
+                # pprint.pprint(event_contenders)
+                assert_equal(event_contenders[0]['name'], "cont1")
+                assert_equal(event_contenders[0]['input-odds'], make_odds(51))
+                assert_equal(event_contenders[0]['outright-odds'], 17844)
+                assert_equal(event_contenders[0]['place-odds'], 13165)
+                assert_equal(event_contenders[0]['show-odds'], 11512)
+                assert_equal(event_contenders[2]['name'], "horse1")
+                assert_equal(event_contenders[2]['input-odds'], make_odds(4))
+                assert_equal(event_contenders[2]['outright-odds'], 205958)
+                assert_equal(event_contenders[2]['place-odds'], 68206)
+                assert_equal(event_contenders[2]['show-odds'], 36967)
+                assert_equal(event_contenders[7]['name'], "horse6")
+                assert_equal(event_contenders[7]['input-odds'], make_odds(5))
+                assert_equal(event_contenders[7]['outright-odds'], 165133)
+                assert_equal(event_contenders[7]['place-odds'], 57603)
+                assert_equal(event_contenders[7]['show-odds'], 32310)
+                assert_equal(event_contenders[8]['name'], "horse7")
+                assert_equal(event_contenders[8]['input-odds'], 0)
+                assert_equal(event_contenders[8]['outright-odds'], 0)
+                assert_equal(event_contenders[8]['place-odds'], 0)
+                assert_equal(event_contenders[8]['show-odds'], 0)
+
+        # Case: update all contenders and close show market
+        field_update_odds_opcode = make_field_update_odds(1, {
+                contender_names.index("cont1") : 0,
+                contender_names.index("cont2") : 0, # close show market
+                contender_names.index("horse1") : make_odds(20),
+                contender_names.index("horse2") : make_odds(5),
+                contender_names.index("horse3") : make_odds(5),
+                contender_names.index("horse4") : make_odds(20),
+                contender_names.index("horse5") : make_odds(25),
+                contender_names.index("horse6") : make_odds(6),
+                contender_names.index("horse7") : make_odds(19)
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_update_odds_opcode = make_field_update_odds(301, {
+                contender_names.index("cont1") : 0,
+                contender_names.index("cont2") : 0, # close show market
+                contender_names.index("horse1") : make_odds(20),
+                contender_names.index("horse2") : make_odds(5),
+                contender_names.index("horse3") : make_odds(5),
+                contender_names.index("horse4") : make_odds(20),
+                contender_names.index("horse5") : make_odds(25),
+                contender_names.index("horse6") : make_odds(6),
+                contender_names.index("horse7") : make_odds(19)
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # print(self.nodes[0].listfieldevents()[1]['contenders'])
+
+        #for node in self.nodes[0:4]:
+        list_events = self.nodes[2].listfieldevents()
+        assert_equal(len(list_events), 4)
+        for event in list_events:
+            if event['event_id'] == 1:
+                assert_equal(len(event['contenders']), 9)
+                event_contenders = event['contenders']
+                # pprint.pprint(event_contenders)
+                assert_equal(event_contenders[0]['name'], "cont1")
+                assert_equal(event_contenders[0]['input-odds'], 0)
+                assert_equal(event_contenders[0]['outright-odds'], 0)
+                assert_equal(event_contenders[0]['place-odds'], 0)
+                assert_equal(event_contenders[0]['show-odds'], 0)
+                assert_equal(event_contenders[1]['name'], "cont2")
+                assert_equal(event_contenders[1]['outright-odds'], 0)
+                assert_equal(event_contenders[1]['place-odds'], 0)
+                assert_equal(event_contenders[1]['show-odds'], 0)
+                assert_equal(event_contenders[2]['name'], "horse1")
+                assert_equal(event_contenders[2]['input-odds'], make_odds(20))
+                assert_equal(event_contenders[2]['outright-odds'], 43587)
+                assert_equal(event_contenders[2]['place-odds'], 22262)
+                assert_equal(event_contenders[2]['show-odds'], 0)
+                assert_equal(event_contenders[7]['name'], "horse6")
+                assert_equal(event_contenders[7]['input-odds'], make_odds(6))
+                assert_equal(event_contenders[7]['outright-odds'], 141549)
+                assert_equal(event_contenders[7]['place-odds'], 61356)
+                assert_equal(event_contenders[7]['show-odds'], 0)
+                assert_equal(event_contenders[8]['name'], "horse7")
+                assert_equal(event_contenders[8]['input-odds'], make_odds(19))
+                assert_equal(event_contenders[8]['outright-odds'], 45796)
+                assert_equal(event_contenders[8]['place-odds'], 23145)
+                assert_equal(event_contenders[8]['show-odds'], 0)
+            if event['event_id'] == 301:
+                assert_equal(len(event['contenders']), 9)
+                event_contenders = event['contenders']
+                # pprint.pprint(event_contenders)
+                assert_equal(event_contenders[0]['name'], "cont1")
+                assert_equal(event_contenders[0]['input-odds'], 0)
+                assert_equal(event_contenders[0]['outright-odds'], 0)
+                assert_equal(event_contenders[0]['place-odds'], 0)
+                assert_equal(event_contenders[0]['show-odds'], 0)
+                assert_equal(event_contenders[1]['name'], "cont2")
+                assert_equal(event_contenders[1]['input-odds'], 0)
+                assert_equal(event_contenders[1]['outright-odds'], 0)
+                assert_equal(event_contenders[1]['place-odds'], 0)
+                assert_equal(event_contenders[1]['show-odds'], 0)
+                assert_equal(event_contenders[2]['name'], "horse1")
+                assert_equal(event_contenders[2]['input-odds'], make_odds(20))
+                assert_equal(event_contenders[2]['outright-odds'], 43587)
+                assert_equal(event_contenders[2]['place-odds'], 22969)
+                assert_equal(event_contenders[2]['show-odds'], 0)
+                assert_equal(event_contenders[7]['name'], "horse6")
+                assert_equal(event_contenders[7]['input-odds'], make_odds(6))
+                assert_equal(event_contenders[7]['outright-odds'], 141549)
+                assert_equal(event_contenders[7]['place-odds'], 54450)
+                assert_equal(event_contenders[7]['show-odds'], 0)
+                assert_equal(event_contenders[8]['name'], "horse7")
+                assert_equal(event_contenders[8]['input-odds'], make_odds(19))
+                assert_equal(event_contenders[8]['outright-odds'], 45796)
+                assert_equal(event_contenders[8]['place-odds'], 23763)
+                assert_equal(event_contenders[8]['show-odds'], 0)
+
+        self.log.info("Revering...")
+
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        # Check event not updated
+        for node in self.nodes:
+            list_events = node.listfieldevents()
+            assert_equal(len(list_events), 4)
+            for event in list_events:
+                if event['event_id'] == 1:
+                    assert_equal(len(event['contenders']), 1)
+                    assert_equal(saved_other_event['contenders'][0]['name'], event['contenders'][0]['name'])
+                    assert_equal(saved_other_event['contenders'][0]['input-odds'], event['contenders'][0]['input-odds'])
+                    assert_equal(saved_other_event['contenders'][0]['outright-odds'], event['contenders'][0]['outright-odds'])
+                    assert_equal(saved_other_event['contenders'][0]['place-odds'], event['contenders'][0]['place-odds'])
+                    assert_equal(saved_other_event['contenders'][0]['show-odds'], event['contenders'][0]['show-odds'])
+                if event['event_id'] == 301:
+                    assert_equal(len(event['contenders']), 1)
+                    assert_equal(saved_animal_event['contenders'][0]['name'], event['contenders'][0]['name'])
+                    assert_equal(saved_animal_event['contenders'][0]['input-odds'], event['contenders'][0]['input-odds'])
+                    assert_equal(saved_animal_event['contenders'][0]['outright-odds'], event['contenders'][0]['outright-odds'])
+                    assert_equal(saved_animal_event['contenders'][0]['place-odds'], event['contenders'][0]['place-odds'])
+                    assert_equal(saved_animal_event['contenders'][0]['show-odds'], event['contenders'][0]['show-odds'])
+
+        self.log.info("Field Event Update Odds Success")
+
+    def check_event_zeroing_odds(self):
+        self.log.info("Check Field Zeroing Odds...")
+        start_time = int(time.time() + 60 * 60)
+
+        field_event_opcode = make_field_event(
+            2,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Sport1"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1")  : make_odds(20),
+                contender_names.index("cont2")  : make_odds(20),
+                contender_names.index("horse1") : make_odds(20),
+                contender_names.index("horse2") : make_odds(20),
+                contender_names.index("horse3") : make_odds(20),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # For revert test
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        field_zeroing_opcode = make_field_zeroing_odds(100) # bad event_id
+        assert_raises_rpc_error(-25, "",
+            post_opcode, self.nodes[1], field_zeroing_opcode, WGR_WALLET_ORACLE['addr'])
+
+        field_zeroing_opcode = make_field_zeroing_odds(2)
+        post_opcode(self.nodes[1], field_zeroing_opcode, WGR_WALLET_ORACLE['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        list_events = self.nodes[2].listfieldevents()
+        for event in list_events:
+            if event['event_id'] != 2:
+                continue
+            assert_equal(len(event['contenders']), 5)
+            assert_equal(event['contenders'][0]['name'], "cont1")
+            assert_equal(event['contenders'][0]['input-odds'], 0)
+            assert_equal(event['contenders'][0]['outright-odds'], 0)
+            assert_equal(event['contenders'][0]['place-odds'], 0)
+            assert_equal(event['contenders'][0]['show-odds'], 0)
+            assert_equal(event['contenders'][1]['name'], "cont2")
+            assert_equal(event['contenders'][1]['input-odds'], 0)
+            assert_equal(event['contenders'][1]['outright-odds'], 0)
+            assert_equal(event['contenders'][1]['place-odds'], 0)
+            assert_equal(event['contenders'][1]['show-odds'], 0)
+            assert_equal(event['contenders'][2]['name'], "horse1")
+            assert_equal(event['contenders'][2]['input-odds'], 0)
+            assert_equal(event['contenders'][2]['outright-odds'], 0)
+            assert_equal(event['contenders'][2]['place-odds'], 0)
+            assert_equal(event['contenders'][2]['show-odds'], 0)
+            assert_equal(event['contenders'][3]['name'], "horse2")
+            assert_equal(event['contenders'][3]['input-odds'], 0)
+            assert_equal(event['contenders'][3]['outright-odds'], 0)
+            assert_equal(event['contenders'][3]['place-odds'], 0)
+            assert_equal(event['contenders'][3]['show-odds'], 0)
+            assert_equal(event['contenders'][4]['name'], "horse3")
+            assert_equal(event['contenders'][4]['input-odds'], 0)
+            assert_equal(event['contenders'][4]['outright-odds'], 0)
+            assert_equal(event['contenders'][4]['place-odds'], 0)
+            assert_equal(event['contenders'][4]['show-odds'], 0)
+
+        self.log.info("Revering...")
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        # print(self.nodes[0].listfieldevents()[2]['contenders'])
+
+        #for node in self.nodes:
+        list_events = self.nodes[2].listfieldevents()
+        for event in list_events:
+            if event['event_id'] != 2:
+                continue
+            # pprint.pprint(event['contenders'])
+            assert_equal(len(event['contenders']), 5)
+            assert_equal(event['contenders'][0]['name'], "cont1")
+            assert_equal(event['contenders'][0]['input-odds'], make_odds(20))
+            assert_equal(event['contenders'][0]['outright-odds'], 43478)
+            assert_equal(event['contenders'][0]['place-odds'], 21819)
+            assert_equal(event['contenders'][0]['show-odds'], 0)
+            assert_equal(event['contenders'][1]['name'], "cont2")
+            assert_equal(event['contenders'][1]['input-odds'], make_odds(20))
+            assert_equal(event['contenders'][1]['outright-odds'], 43478)
+            assert_equal(event['contenders'][1]['place-odds'], 21819)
+            assert_equal(event['contenders'][1]['show-odds'], 0)
+            assert_equal(event['contenders'][2]['name'], "horse1")
+            assert_equal(event['contenders'][2]['input-odds'], make_odds(20))
+            assert_equal(event['contenders'][2]['outright-odds'], 43478)
+            assert_equal(event['contenders'][2]['place-odds'], 21819)
+            assert_equal(event['contenders'][2]['show-odds'], 0)
+            assert_equal(event['contenders'][3]['name'], "horse2")
+            assert_equal(event['contenders'][3]['input-odds'], make_odds(20))
+            assert_equal(event['contenders'][3]['outright-odds'], 43478)
+            assert_equal(event['contenders'][3]['place-odds'], 21819)
+            assert_equal(event['contenders'][3]['show-odds'], 0)
+            assert_equal(event['contenders'][4]['name'], "horse3")
+            assert_equal(event['contenders'][4]['input-odds'], make_odds(20))
+            assert_equal(event['contenders'][4]['outright-odds'], 43478)
+            assert_equal(event['contenders'][4]['place-odds'], 21819)
+            assert_equal(event['contenders'][4]['show-odds'], 0)
+
+        self.log.info("Field Event Zeroing Odds Success")
+
+    def check_field_bet_undo(self):
+        self.log.info("Check Field Bets undo...")
+        start_time = int(time.time() + 60 * 60)
+
+        field_event_opcode = make_field_event(
+            221,
+            start_time,
+            other_group,
+            all_markets,
+            sport_names.index("F1 racing"),
+            tournament_names.index("F1 Cup"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("Alexander Albon") : make_odds(25),
+                contender_names.index("Pierre Gasly")    : make_odds(25),
+                contender_names.index("Romain Grosjean") : make_odds(15),
+                contender_names.index("Antonio Maria Giovinazzi")   : make_odds(35),
+                contender_names.index("cont1") : 0
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # For revert test
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        player1_bet = 30
+        self.nodes[2].placefieldbet(221, market_outright, contender_names.index("Alexander Albon"), player1_bet)
+
+        events = self.nodes[2].listfieldevents()
+        bet_contender_info = {}
+        for event in events:
+            if event['event_id'] == 221:
+                for contender in event['contenders']:
+                    if contender['name'] == "Alexander Albon":
+                        bet_contender_info = contender
+
+        effective_odds = calc_effective_odds(Decimal(bet_contender_info['outright-odds']))
+        player1_expected_win = effective_odds * player1_bet / ODDS_DIVISOR
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        event_stats = self.nodes[2].getfieldeventliability(221)
+        assert_equal(event_stats["event-id"], 221)
+        assert_equal(event_stats["event-status"], "running")
+        assert_equal(len(event_stats["contenders"]), 5)
+        for contender in event_stats["contenders"]:
+            if contender["contender-id"] != contender_names.index("Alexander Albon"):
+                continue
+            assert_equal(contender["outright-bets"], 1)
+            assert_equal(contender["outright-liability"], int(player1_expected_win))
+
+        field_result_opcode = make_field_result(221, STANDARD_RESULT, {
+            contender_names.index("Alexander Albon") : place1,
+            contender_names.index("Romain Grosjean") : place2,
+            contender_names.index("Antonio Maria Giovinazzi") : place3
+        })
+
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # Check event closed
+        assert_raises_rpc_error(-31, "Error: FieldEvent " + str(221) + " was been resulted",
+            self.nodes[2].placefieldbet, 221, market_outright, contender_names.index("Alexander Albon"), 30)
+
+        #for node in self.nodes[0:4]:
+        event_stats = self.nodes[1].getfieldeventliability(221)
+        assert_equal(event_stats["event-id"], 221)
+        assert_equal(event_stats["event-status"], "resulted")
+
+        self.log.info("Revering...")
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        #for node in self.nodes:
+        event_stats = self.nodes[2].getfieldeventliability(221)
+        assert_equal(event_stats["event-id"], 221)
+        assert_equal(event_stats["event-status"], "running")
+        assert_equal(len(event_stats["contenders"]), 5)
+        for contender in event_stats["contenders"]:
+            assert_equal(contender["outright-bets"], 0)
+            assert_equal(contender["outright-liability"], 0)
+
+        self.log.info("Check Field Bets undo success")
+
+    def check_field_bet_outright(self):
+        self.log.info("Check Field Bets outright market...")
+        start_time = int(time.time() + 60 * 60)
+
+        global player1_total_bet
+        global player2_total_bet
+
+        player1_total_bet = 0
+        player2_total_bet = 0
+
+        # Create events for bet tests
+        # event have 9 contenders, but only outright market available
+        field_event_opcode = make_field_event(
+            3,
+            start_time,
+            other_group,
+            outright_only,
+            sport_names.index("F1 racing"),
+            tournament_names.index("F1 Cup"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("Alexander Albon") : make_odds(25),
+                contender_names.index("Pierre Gasly")    : make_odds(25),
+                contender_names.index("Romain Grosjean") : make_odds(15),
+                contender_names.index("Antonio Maria Giovinazzi")   : make_odds(35),
+                contender_names.index("cont1") : 0,
+                contender_names.index("cont2") : make_odds(20),
+                contender_names.index("cont3") : make_odds(20),
+                contender_names.index("cont4") : make_odds(20),
+                contender_names.index("cont5") : make_odds(20),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        field_event_opcode = make_field_event(
+            4,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(20),
+                contender_names.index("horse2") : make_odds(19),
+                contender_names.index("horse3") : make_odds(21),
+                contender_names.index("horse4") : make_odds(15),
+                contender_names.index("horse5") : make_odds(25)
+            }
+        )
+
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_event_opcode = make_field_event(
+            5,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round1"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(33.3),
+                contender_names.index("horse2") : make_odds(33.3),
+                contender_names.index("horse3") : make_odds(33.3)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placefieldbet, 3, market_outright, contender_names.index("Alexander Albon"), 24)
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placefieldbet, 3, market_outright, contender_names.index("Alexander Albon"), 10001)
+        assert_raises_rpc_error(-31, "Error: there is no such FieldEvent: {}".format(202),
+            self.nodes[2].placefieldbet, 202, market_outright, contender_names.index("Alexander Albon"), 30)
+        assert_raises_rpc_error(-31, "Error: Incorrect bet market type for FieldEvent: {}".format(3),
+            self.nodes[2].placefieldbet, 3, 100, contender_names.index("Alexander Albon"), 30)
+        assert_raises_rpc_error(-31, "Error: there is no such contenderId {} in event {}".format(1050, 3),
+            self.nodes[2].placefieldbet, 3, market_outright, 1050, 30)
+        assert_raises_rpc_error(-31, "Error: contender odds is zero for event: {} contenderId: {}".format(3, contender_names.index("cont1")),
+            self.nodes[2].placefieldbet, 3, market_outright, contender_names.index("cont1"), 30)
+        # try to place bet at closed market type
+        assert_raises_rpc_error(-31, "Error: market {} is closed for event {}".format(market_place, 3),
+            self.nodes[2].placefieldbet, 3, market_place, contender_names.index("cont2"), 30)
+        assert_raises_rpc_error(-31, "Error: market {} is closed for event {}".format(market_show, 3),
+            self.nodes[2].placefieldbet, 3, market_show, contender_names.index("cont3"), 30)
+
+        events = self.nodes[2].listfieldevents()
+        bet_contender_info = {}
+        for event in events:
+            if event['event_id'] == 3:
+                for contender in event['contenders']:
+                    if contender['name'] == "Romain Grosjean":
+                        bet_contender_info = contender
+        # player1 makes win bet to event3
+        player1_bet = 30
+        player1_total_bet += player1_bet
+        self.nodes[2].placefieldbet(3, market_outright, contender_names.index("Romain Grosjean"), player1_bet)
+
+        onchainOdds = Decimal(bet_contender_info["outright-odds"])
+        effectiveOdds = ((onchainOdds - ODDS_DIVISOR) * 9400) // ODDS_DIVISOR + ODDS_DIVISOR
+        player1_expected_win = (player1_bet * effectiveOdds) / ODDS_DIVISOR
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        field_update_odds_opcode = make_field_update_odds(
+            3,
+            {
+                contender_names.index("Romain Grosjean") : 14000,
+                contender_names.index("cont2") : 11000 # Add new conteder
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        events = self.nodes[3].listfieldevents()
+        bet_contender_info = {}
+        for event in events:
+            if event['event_id'] == 3:
+                for contender in event['contenders']:
+                    if contender['name'] == "Romain Grosjean":
+                        bet_contender_info = contender
+        # player2 makes win bet to event3 after changed odds
+        player2_bet = 30
+        player2_total_bet += player2_bet
+        self.nodes[3].placefieldbet(3, market_outright, contender_names.index("Romain Grosjean"), player2_bet)
+
+        effectiveOdds = calc_effective_odds(Decimal(bet_contender_info["outright-odds"]))
+        player2_expected_win = (player2_bet * effectiveOdds) / ODDS_DIVISOR
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        field_result_opcode = make_field_result(
+            3,
+            STANDARD_RESULT,
+            {
+                contender_names.index("Romain Grosjean") : place1,
+                contender_names.index("Pierre Gasly") : place2,
+                contender_names.index("cont2") : place3
+            }
+        )
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        assert_raises_rpc_error(-31, "Error: FieldEvent 3 was been resulted",
+            self.nodes[2].placefieldbet, 3, market_outright, contender_names.index("Alexander Albon"), 30)
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+        player2_balance_before =  Decimal(self.nodes[3].getbalance())
+
+        # make block with payouts
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+        player2_balance_after = Decimal(self.nodes[3].getbalance())
+
+        assert_equal(player1_balance_after, player1_balance_before + player1_expected_win)
+        assert_equal(player2_balance_after, player2_balance_before + player2_expected_win)
+
+        # player1 makes lose bet to event4
+        player1_bet = 40
+        player1_total_bet += player1_bet
+        self.nodes[2].placefieldbet(4, market_outright, contender_names.index("horse2"), player1_bet)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        field_update_odds_opcode = make_field_update_odds(
+            4,
+            {
+                contender_names.index("horse1") : make_odds(25),
+                contender_names.index("horse3") : make_odds(25),
+                contender_names.index("horse6") : make_odds(16) # Add new conteder
+            }
+        )
+        post_opcode(self.nodes[1], field_update_odds_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # player2 makes win bet to event4
+        player2_bet = 40
+        player2_total_bet += player2_bet
+        self.nodes[3].placefieldbet(4, market_outright, contender_names.index("horse6"), player2_bet)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # make result for event3 and check payouts and players balances
+        field_result_opcode = make_field_result(4, STANDARD_RESULT, {
+            contender_names.index("horse6") : place1,
+            contender_names.index("horse3") : place2,
+            contender_names.index("horse5") : place3,
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # TODO: for event4 calculate wins and check payouts/balances
+
+        self.log.info("Field Bets outright market Success")
+
+    def check_field_bet_place(self):
+        # TODO: create field event
+        # TODO: check place market closed (contenders size)
+        # update event to place market
+        # placefield bet
+        # event result
+        # calculate
+        pass
+
+    def check_field_bet_show(self):
+        # TODO: create field event
+        # TODO: check show market closed (contenders size)
+        # update event to show market
+        # placefield bet
+        # event result
+        # calculate
+        pass
+
+    def check_parlays_field_bet_undo(self):
+        self.log.info("Check Parlay Field Bets Undo...")
+        start_time = int(time.time() + 60 * 60)
+
+        field_event_opcode = make_field_event(
+            231,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(20),
+                contender_names.index("horse2") : make_odds(20),
+                contender_names.index("horse3") : make_odds(20),
+                contender_names.index("horse4") : make_odds(20),
+                contender_names.index("horse5") : make_odds(20)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        field_event_opcode = make_field_event(
+            232,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(25),
+                contender_names.index("horse2") : make_odds(25),
+                contender_names.index("horse3") : make_odds(25),
+                contender_names.index("horse4") : make_odds(25),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # For revert test
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        player1_bet = 30
+        self.nodes[2].placefieldparlaybet(
+            [
+                {"eventId": 231, "marketType": market_outright, "contenderId": contender_names.index("horse1")},
+                {"eventId": 232, "marketType": market_outright, "contenderId": contender_names.index("horse4")},
+            ],
+            player1_bet
+        )
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        event_stats = self.nodes[1].getfieldeventliability(231)
+        assert_equal(event_stats["event-status"], "running")
+        for contender in event_stats["contenders"]:
+            if contender["contender-id"] == contender_names.index("horse1"):
+                assert_equal(contender["outright-bets"], 1)
+            else:
+                assert_equal(contender["outright-bets"], 0)
+
+        # for node in self.nodes[0:4]:
+        event_stats = self.nodes[1].getfieldeventliability(232)
+        assert_equal(event_stats["event-status"], "running")
+        for contender in event_stats["contenders"]:
+            if contender["contender-id"] == contender_names.index("horse4"):
+                assert_equal(contender["outright-bets"], 1)
+            else:
+                assert_equal(contender["outright-bets"], 0)
+
+        field_result_opcode = make_field_result(231, STANDARD_RESULT, {
+            contender_names.index("horse1") : place1,
+            contender_names.index("horse2") : place2,
+            contender_names.index("horse3") : place3
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_result_opcode = make_field_result(232, STANDARD_RESULT, {
+            contender_names.index("horse1") : place1,
+            contender_names.index("horse2") : place2,
+            contender_names.index("horse3") : place3
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        # for node in self.nodes[0:4]:
+        event_stats = self.nodes[2].getfieldeventliability(231)
+        assert_equal(event_stats["event-status"], "resulted")
+
+        # for node in self.nodes[0:4]:
+        event_stats = self.nodes[2].getfieldeventliability(232)
+        assert_equal(event_stats["event-status"], "resulted")
+
+        self.log.info("Revering...")
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        #for node in self.nodes:
+        event_stats = self.nodes[2].getfieldeventliability(231)
+        assert_equal(event_stats["event-status"], "running")
+        for contender in event_stats["contenders"]:
+            assert_equal(contender["outright-bets"], 0)
+            assert_equal(contender["outright-liability"], 0)
+
+        # for node in self.nodes:
+        event_stats = self.nodes[2].getfieldeventliability(232)
+        assert_equal(event_stats["event-status"], "running")
+        for contender in event_stats["contenders"]:
+            assert_equal(contender["outright-bets"], 0)
+            assert_equal(contender["outright-liability"], 0)
+
+        self.log.info("Check Parlay Field Bets Undo Success")
+
+    def check_parlays_field_bet(self):
+        self.log.info("Check Parlay Field Bets...")
+        start_time = int(time.time() + 60 * 60)
+
+        global player1_total_bet
+
+        # For round1 tests
+        field_event_opcode = make_field_event(
+            6,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round1"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(25),
+                contender_names.index("horse2") : make_odds(25),
+                contender_names.index("horse3") : make_odds(25),
+                contender_names.index("horse4") : make_odds(25),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        show_market_event_id = 7
+        field_event_opcode = make_field_event(
+            show_market_event_id,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(10),
+                contender_names.index("horse2") : make_odds(11),
+                contender_names.index("horse3") : make_odds(12),
+                contender_names.index("horse4") : make_odds(13),
+                contender_names.index("horse5") : make_odds(14),
+                contender_names.index("horse6") : make_odds(20),
+                contender_names.index("horse7") : make_odds(15),
+                contender_names.index("horse8") : 0, # for zero odds test,
+                contender_names.index("horse9") : make_odds(5),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        place_market_event_id = 8
+        field_event_opcode = make_field_event(
+            place_market_event_id,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(30),
+                contender_names.index("horse2") : make_odds(11),
+                contender_names.index("horse3") : make_odds(12),
+                contender_names.index("horse4") : make_odds(13),
+                contender_names.index("horse5") : make_odds(14),
+                contender_names.index("horse6") : make_odds(20),
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        outright_market_event_id = 9
+        field_event_opcode = make_field_event(
+            outright_market_event_id,
+            start_time,
+            animal_racing_group,
+            all_markets,
+            sport_names.index("Horse racing"),
+            tournament_names.index("The BMW stakes"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("horse1") : make_odds(30),
+                contender_names.index("horse2") : make_odds(20),
+                contender_names.index("horse3") : make_odds(25),
+                contender_names.index("horse4") : make_odds(25)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 24)
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 10001)
+        assert_raises_rpc_error(-31, "Error: there is no such FieldEvent: {}".format(402),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse1")},
+                {"eventId": 402,                  "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: Incorrect bet market type for FieldEvent: {}".format(show_market_event_id),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": 100, "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: there is no such contenderId {} in event {}".format(1050, show_market_event_id),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": 1050},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: contender odds is zero for event: {} contenderId: {}".format(show_market_event_id, contender_names.index("horse8")),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse8")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: event {} cannot be part of parlay bet".format(5),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": 5, "marketType": market_outright, "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: market {} is closed for event {}".format(market_show, place_market_event_id),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": show_market_event_id, "marketType": market_show,  "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse4")},
+            ], 30)
+        assert_raises_rpc_error(-31, "Error: market {} is closed for event {}".format(market_place, outright_market_event_id),
+            self.nodes[2].placefieldparlaybet, [
+                {"eventId": outright_market_event_id, "marketType": market_place,  "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse4")},
+            ], 30)
+
+        # Player1 place win parlay bet
+        player1_bet = 40
+        parlay_bet_tx = self.nodes[2].placefieldparlaybet(
+            [
+                {"eventId": outright_market_event_id, "marketType": market_outright,  "contenderId": contender_names.index("horse1")},
+                {"eventId": place_market_event_id, "marketType": market_place, "contenderId": contender_names.index("horse5")},
+                {"eventId": show_market_event_id, "marketType": market_show, "contenderId": contender_names.index("horse7")},
+            ], player1_bet
+        )
+        # TODO: player_1 expected win calculate
+        events = self.nodes[2].listfieldevents()
+        effective_parlay_bet_odds = []
+        for event in events:
+            if event['event_id'] == outright_market_event_id:
+                for contender in event['contenders']:
+                    if contender['name'] == "horse1":
+                        effective_parlay_bet_odds.append(calc_effective_odds(int(contender['outright-odds'])))
+            elif event['event_id'] == place_market_event_id:
+                for contender in event['contenders']:
+                    if contender['name'] == "horse5":
+                        effective_parlay_bet_odds.append(calc_effective_odds(int(contender['place-odds'])))
+            elif event['event_id'] == show_market_event_id:
+                for contender in event['contenders']:
+                    if contender['name'] == "horse7":
+                        effective_parlay_bet_odds.append(calc_effective_odds(int(contender['show-odds'])))
+
+        final_effective_odds = 0
+        first_multiply = True
+        for odds in effective_parlay_bet_odds:
+            if first_multiply:
+                final_effective_odds = odds
+                first_multiply = False
+            else:
+                final_effective_odds = (final_effective_odds * odds) // ODDS_DIVISOR
+
+        player1_expected_win = player1_bet * Decimal(final_effective_odds) / ODDS_DIVISOR
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        parlay_bet = self.nodes[0].getbetbytxid(parlay_bet_tx)
+
+        for event_id in [outright_market_event_id, place_market_event_id, show_market_event_id]:
+            # for node in self.nodes:
+            event_stats = self.nodes[2].getfieldeventliability(event_id)
+            assert_equal(event_stats["event-status"], "running")
+            for contender in event_stats["contenders"]:
+                if event_id == outright_market_event_id and contender["contender-id"] == contender_names.index("horse1"):
+                    assert_equal(contender["outright-bets"], 1)
+                    assert_equal(contender["place-bets"], 0)
+                    assert_equal(contender["show-bets"], 0)
+                if event_id == place_market_event_id and contender["contender-id"] == contender_names.index("horse5"):
+                    assert_equal(contender["outright-bets"], 0)
+                    assert_equal(contender["place-bets"], 1)
+                    assert_equal(contender["show-bets"], 0)
+                if event_id == show_market_event_id and contender["contender-id"] == contender_names.index("horse7"):
+                    assert_equal(contender["outright-bets"], 0)
+                    assert_equal(contender["place-bets"], 0)
+                    assert_equal(contender["show-bets"], 1)
+
+        # make results
+        field_result_opcode = make_field_result(outright_market_event_id, STANDARD_RESULT, {
+            contender_names.index("horse1") : place1,
+            contender_names.index("horse3") : place2,
+            contender_names.index("horse4") : place3,
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_result_opcode = make_field_result(place_market_event_id, STANDARD_RESULT, {
+            contender_names.index("horse3") : place1,
+            contender_names.index("horse5") : place2,
+            contender_names.index("horse1") : place3,
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        field_result_opcode = make_field_result(show_market_event_id, STANDARD_RESULT, {
+            contender_names.index("horse2") : place1,
+            contender_names.index("horse1") : place2,
+            contender_names.index("horse7") : place3,
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        player1_balance_before = Decimal(self.nodes[2].getbalance())
+
+        # make block with payouts
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        player1_balance_after = Decimal(self.nodes[2].getbalance())
+
+        payout = player1_balance_after - player1_balance_before
+
+        # print("Expected win: " + str(player1_expected_win))
+        # print("payout: " + str(payout))
+
+        # calculated odds in test and in chain have small difference due accuracy
+        # assert_equal(player1_balance_after, player1_balance_before + player1_expected_win)
+
+        parlay_bet = self.nodes[0].getbetbytxid(parlay_bet_tx)
+
+        self.log.info("Parlay Field Bets Success")
+
+    def check_timecut_refund(self):
+        self.log.info("Check Timecut Refund...")
+
+        # TODO: check
+
+        self.log.info("Timecut Refund Success")
+
+    def run_test(self):
+        self.check_minting()
+        # Chain height = 300 after minting -> v4 protocol active
+        self.check_mapping()
+        self.check_event()
+        self.check_event_update_odds()
+        self.check_event_zeroing_odds()
+        # TODO: check big size transactions (lots of contenders)
+        self.check_field_bet_undo()
+        self.check_field_bet_outright()
+        # self.check_field_bet_place() # TODO
+        # self.check_field_bet_show() # TODO
+        self.check_parlays_field_bet_undo()
+        self.check_parlays_field_bet()
+        # self.check_timecut_refund() # TODO
+
+if __name__ == '__main__':
+    BettingTest().main()
+    # check_calculate_odds()

--- a/test/functional/feature_hybrid_betting.py
+++ b/test/functional/feature_hybrid_betting.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Wagerr  developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+from test_framework.betting_opcode import *
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import WagerrTestFramework
+from test_framework.util import wait_until, rpc_port, assert_equal, assert_raises_rpc_error, sync_blocks, connect_nodes
+from distutils.dir_util import copy_tree, remove_tree
+from decimal import *
+import pprint
+import time
+import os
+import ctypes
+import copy
+
+WGR_WALLET_ORACLE = { "addr": "TXuoB9DNEuZx1RCfKw3Hsv7jNUHTt4sVG1", "key": "TBwvXbNNUiq7tDkR2EXiCbPxEJRTxA1i6euNyAE9Ag753w36c1FZ" }
+WGR_WALLET_EVENT = { "addr": "TFvZVYGdrxxNunQLzSnRSC58BSRA7si6zu", "key": "TCDjD2i4e32kx2Fc87bDJKGBedEyG7oZPaZfp7E1PQG29YnvArQ8" }
+WGR_WALLET_DEV = { "addr": "TLuTVND9QbZURHmtuqD5ESECrGuB9jLZTs", "key": "TFCrxaUt3EjHzMGKXeBqA7sfy3iaeihg5yZPSrf9KEyy4PHUMWVe" }
+WGR_WALLET_OMNO = { "addr": "THofaueWReDjeZQZEECiySqV9GP4byP3qr", "key": "TDJnwRkSk8JiopQrB484Ny9gMcL1x7bQUUFFFNwJZmmWA7U79uRk" }
+
+pl_sport_names = ["PeerlessSport"]
+field_sport_names = ["FieldSport"]
+round_names = ["round0"]
+tournament_names = ["Tournament1", "Tournament2"]
+team_names = ["Team1", "Team2", "Team3", "Team4"]
+contender_names = ["cont1", "cont2", "cont3", "cont4", "cont5", "cont6", "cont7", "cont8", "cont9",
+]
+
+outcome_home_win = 1
+outcome_away_win = 2
+outcome_draw = 3
+outcome_spread_home = 4
+outcome_spread_away = 5
+outcome_total_over = 6
+outcome_total_under = 7
+
+# Field event groups
+other_group = 1
+animal_racing_group = 2
+
+# Field event market type
+all_markets = 1
+outright_only = 2
+
+# Field bet market types
+market_outright = 1
+market_place    = 2
+market_show     = 3
+
+# Contender result types
+DNF    = 0
+place1 = 1
+place2 = 2
+place3 = 3
+DNR    = 101
+
+def make_field_odds(probability_percent):
+    if probability_percent == 0:
+        return 0
+    return int((1 / (probability_percent / 100)) * ODDS_DIVISOR)
+
+class HybridBettingTest(WagerrTestFramework):
+    def get_node_setting(self, node_index, setting_name):
+        with open(os.path.join(self.nodes[node_index].datadir, "wagerr.conf"), 'r', encoding='utf8') as f:
+            for line in f:
+                if line.startswith(setting_name + "="):
+                    return line.split("=")[1].strip("\n")
+        return None
+
+    def get_local_peer(self, node_index, is_rpc=False):
+        port = self.get_node_setting(node_index, "rpcport" if is_rpc else "port")
+        return "127.0.0.1:" + str(rpc_port(node_index) if port is None else port)
+
+    def set_test_params(self):
+        # 0 - main node
+        # 1 - oracle
+        # 2 - player1
+        # 3 - player2
+        # 4 - revert testing
+        self.num_nodes = 5
+        self.extra_args = [[] for n in range(self.num_nodes)]
+        self.setup_clean_chain = True
+        self.players = []
+        # { event_id : { contender_id : odds, ... } }
+        self.mrg_in_percent = 11500 # 115.00%
+
+    def connect_network(self):
+        for i in range(len(self.nodes)):
+            for j in range(len(self.nodes)):
+                if i == j:
+                    continue
+                self.nodes[i].addnode(self.get_local_peer(j), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[i].getpeerinfo()))
+        self.sync_all()
+        for n in range(self.num_nodes):
+            idx_l = n
+            idx_r = n + 1 if n + 1 < self.num_nodes else 0
+            assert_equal(self.nodes[idx_l].getblockcount(), self.nodes[idx_r].getblockcount())
+
+    def connect_and_sync_blocks(self):
+        for i in range(self.num_nodes):
+            for j in range(self.num_nodes):
+                if i == j:
+                    continue
+                self.nodes[i].addnode(self.get_local_peer(j), "onetry")
+                wait_until(lambda:  all(peer['version'] != 0 for peer in self.nodes[i].getpeerinfo()))
+        sync_blocks(self.nodes)
+
+    def setup_network(self):
+        self.log.info("Setup Network")
+        self.setup_nodes()
+        self.connect_network()
+
+    def check_minting(self, block_count=250):
+        self.log.info("Check Minting...")
+
+        self.nodes[1].importprivkey(WGR_WALLET_ORACLE['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_EVENT['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_DEV['key'])
+        self.nodes[1].importprivkey(WGR_WALLET_OMNO['key'])
+
+        self.players.append(self.nodes[2].getnewaddress('Node2Addr'))
+        self.players.append(self.nodes[3].getnewaddress('Node3Addr'))
+        node4Addr = self.nodes[4].getnewaddress('Node4Addr')
+        self.log.info("node4Addr = " + str(node4Addr))
+        self.log.info("player1 addr = " + str(self.players[0]))
+        self.log.info("player2 addr = " + str(self.players[1]))
+
+        for i in range(block_count - 1):
+            blocks = self.nodes[0].generate(1)
+            blockinfo = self.nodes[0].getblock(blocks[0])
+            # get coinbase tx
+            rawTx = self.nodes[0].getrawtransaction(blockinfo['tx'][0])
+            decodedTx = self.nodes[0].decoderawtransaction(rawTx)
+            address = decodedTx['vout'][0]['scriptPubKey']['addresses'][0]
+            #if (i > 0):
+                #
+                # minting must process to sigle address
+                # assert_equal(address, prevAddr)
+            prevAddr = address
+
+        for i in range(30):
+            self.nodes[0].sendtoaddress(WGR_WALLET_ORACLE['addr'], 2000)
+            self.nodes[0].sendtoaddress(WGR_WALLET_EVENT['addr'], 2000)
+            self.nodes[0].sendtoaddress(self.players[0], 2000)
+            self.nodes[0].sendtoaddress(self.players[1], 2000)
+
+        for i in range(30):
+            self.nodes[0].sendtoaddress(node4Addr, 2000)
+
+        self.nodes[0].generate(51)
+        for r in range(self.num_nodes):
+            self.stop_node(r)
+            self.start_node(r)
+
+        for n in range(self.num_nodes -1 ):
+            connect_nodes(self.nodes[0], (n+1))
+        self.sync_all()
+
+        for n in range(self.num_nodes):
+            assert_equal( self.nodes[n].getblockcount(), 300)
+
+        assert_equal(self.nodes[1].getbalance(), 120000) # oracle
+        assert_equal(self.nodes[2].getbalance(), 60000) # player1
+        assert_equal(self.nodes[3].getbalance(), 60000) # player2
+        assert_equal(self.nodes[4].getbalance(), 60000) # revert node
+
+        self.log.info("Minting Success")
+
+    def check_mapping(self):
+        self.log.info("Check Mapping...")
+
+        self.nodes[0].generate(199)
+        sync_blocks(self.nodes)
+
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingid, "", "")
+        assert_raises_rpc_error(-1, "No mapping exist for the mapping index you provided.", self.nodes[0].getmappingname, "abc123", 0)
+
+        # add peerless sports to mapping
+        for id in range(len(pl_sport_names)):
+            mapping_opcode = make_mapping(SPORT_MAPPING, id, pl_sport_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        # add field sports to mapping
+        for id in range(len(field_sport_names)):
+            mapping_opcode = make_mapping(INDIVIDUAL_SPORT_MAPPING, id, field_sport_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # add tournaments to mapping
+        for id in range(len(tournament_names)):
+            mapping_opcode = make_mapping(TOURNAMENT_MAPPING, id, tournament_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # add rounds to mapping
+        for id in range(len(round_names)):
+            mapping_opcode = make_mapping(ROUND_MAPPING, id, round_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # add contenders to mapping
+        for id in range(len(contender_names)):
+            mapping_opcode = make_mapping(CONTENDER_MAPPING, id, contender_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        # add teams to mapping
+        for id in range(len(team_names)):
+            mapping_opcode = make_mapping(TEAM_MAPPING, id, team_names[id])
+            post_opcode(self.nodes[1], mapping_opcode, WGR_WALLET_ORACLE['addr'])
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+
+        self.log.info("Mapping Success")
+
+    def check_hybrid_parlay_bets(self):
+
+        self.start_time = int(time.time() + 60 * 60)
+        # make pl event 1
+        plEvent = make_event(0, # Event ID
+                            self.start_time, # start time = current + hour
+                            pl_sport_names.index("PeerlessSport"), # Sport ID
+                            tournament_names.index("Tournament1"), # Tournament ID
+                            round_names.index("round0"), # Round ID
+                            team_names.index("Team1"), # Home Team
+                            team_names.index("Team2"), # Away Team
+                            15000, # home odds
+                            18000, # away odds
+                            13000) # draw odds
+        breakpoint()
+        post_opcode(self.nodes[1], plEvent, WGR_WALLET_EVENT['addr'])
+
+        # make pl event 2
+        plEvent = make_event(1, # Event ID
+                            self.start_time, # start time = current + hour
+                            pl_sport_names.index("PeerlessSport"), # Sport ID
+                            tournament_names.index("Tournament1"), # Tournament ID
+                            round_names.index("round0"), # Round ID
+                            team_names.index("Team3"), # Home Team
+                            team_names.index("Team4"), # Away Team
+                            10000, # home odds
+                            20000, # away odds
+                            18000) # draw odds
+        post_opcode(self.nodes[1], plEvent, WGR_WALLET_EVENT['addr'])
+
+        # make field event 1
+        field_event_opcode = make_field_event(
+            0,
+            self.start_time,
+            animal_racing_group,
+            all_markets,
+            field_sport_names.index("FieldSport"),
+            tournament_names.index("Tournament1"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1"): make_field_odds(10),
+                contender_names.index("cont2"): make_field_odds(11),
+                contender_names.index("cont3"): make_field_odds(12),
+                contender_names.index("cont4"): make_field_odds(13),
+                contender_names.index("cont5"): make_field_odds(14),
+                contender_names.index("cont6"): make_field_odds(20),
+                contender_names.index("cont7"): make_field_odds(15),
+                contender_names.index("cont8"): make_field_odds(5),
+                contender_names.index("cont9"): make_field_odds(0)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        # make field event 2
+        field_event_opcode = make_field_event(
+            1,
+            self.start_time,
+            animal_racing_group,
+            all_markets,
+            field_sport_names.index("FieldSport"),
+            tournament_names.index("Tournament2"),
+            round_names.index("round0"),
+            self.mrg_in_percent,
+            {
+                contender_names.index("cont1"): make_field_odds(15),
+                contender_names.index("cont2"): make_field_odds(5),
+                contender_names.index("cont3"): make_field_odds(13),
+                contender_names.index("cont4"): make_field_odds(16),
+                contender_names.index("cont5"): make_field_odds(5),
+                contender_names.index("cont6"): make_field_odds(3),
+                contender_names.index("cont7"): make_field_odds(4),
+                contender_names.index("cont8"): make_field_odds(0),
+                contender_names.index("cont9"): make_field_odds(0)
+            }
+        )
+        post_opcode(self.nodes[1], field_event_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes)
+
+        player1_legs = [
+            {
+                "legType": "peerless",
+                "legObj": {
+                    "eventId": 0, # pl event 0
+                    "outcome": outcome_home_win # Team1 win
+                }
+            },
+            {
+                "legType": "peerless",
+                "legObj": {
+                    "eventId": 1, # pl event 1
+                    "outcome": outcome_away_win # Team4 win
+                }
+            },
+            {
+                "legType": "field",
+                "legObj": {
+                    "eventId": 0, # field event 0
+                    "marketType": market_outright, # contender1 will take 1st place
+                    "contenderId": contender_names.index("cont1")
+                }
+            },
+            {
+                "legType": "field",
+                "legObj": {
+                    "eventId": 1, # field event 0
+                    "marketType": market_place, # contender2 will take 1st or 2nd place
+                    "contenderId": contender_names.index("cont2")
+                }
+            }
+        ]
+
+        # try to place hybrid bet with one leg
+        assert_raises_rpc_error(-31, "Error: Incorrect legs count.",
+            self.nodes[2].placehybridparlaybet, player1_legs[:1], 100)
+
+        # invalid amount
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placehybridparlaybet, player1_legs, 24)
+        assert_raises_rpc_error(-31, "Incorrect bet amount. Please ensure your bet is between 25 - 10000 WGR inclusive.",
+            self.nodes[2].placehybridparlaybet, player1_legs, 10001)
+
+        # invalid pl event
+        failed_legs = copy.deepcopy(player1_legs)
+        failed_legs[0]['legObj']['eventId'] = 101
+        assert_raises_rpc_error(-31, "Error: there is no such Event: {}".format(101),
+            self.nodes[2].placehybridparlaybet, failed_legs, 30)
+        # invalid field event
+        failed_legs = copy.deepcopy(player1_legs)
+        failed_legs[3]['legObj']['eventId'] = 201
+        assert_raises_rpc_error(-31, "Error: there is no such FieldEvent: {}".format(201),
+            self.nodes[2].placehybridparlaybet, failed_legs, 30)
+
+        revert_chain_height = self.nodes[4].getblockcount()
+        self.stop_node(4)
+
+        player1_bet_tx = self.nodes[2].placehybridparlaybet(player1_legs, 100)
+
+        player2_legs = copy.deepcopy(player1_legs)
+        # make for player2 3rd leg as loss
+        # cont2 will not take 1st place
+        player2_legs[2]['legObj']['contenderId'] = contender_names.index("cont2")
+        player2_bet_tx = self.nodes[3].placehybridparlaybet(player2_legs, 200)
+
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        player1_bet = self.nodes[0].getbetbytxid(player1_bet_tx)
+        player2_bet = self.nodes[0].getbetbytxid(player2_bet_tx)
+
+        # pl event 0, home team win
+        result_opcode = make_result(0, STANDARD_RESULT, 2, 0)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+        # pl event 1, away team win
+        result_opcode = make_result(1, STANDARD_RESULT, 0, 1)
+        post_opcode(self.nodes[1], result_opcode, WGR_WALLET_EVENT['addr'])
+        # field event 0
+        field_result_opcode = make_field_result(0, STANDARD_RESULT, {
+            contender_names.index("cont1") : place1,
+            contender_names.index("cont2") : place2,
+            contender_names.index("cont3") : place3
+        })
+        # field event 1
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+        field_result_opcode = make_field_result(1, STANDARD_RESULT, {
+            contender_names.index("cont1") : place1,
+            contender_names.index("cont2") : place2,
+            contender_names.index("cont3") : place3
+        })
+        post_opcode(self.nodes[1], field_result_opcode, WGR_WALLET_EVENT['addr'])
+
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        player1_balance_before = self.nodes[2].getbalance()
+        player2_balance_before = self.nodes[3].getbalance()
+
+        # generate payouts
+        self.nodes[1].generate(1)
+        sync_blocks(self.nodes[0:4])
+
+        player1_balance_after = self.nodes[2].getbalance()
+        player2_balance_after = self.nodes[3].getbalance()
+
+        print("player1_balance_before: ", player1_balance_before)
+        print("player1_balance_after: ", player1_balance_after)
+
+        player1_payout = player1_balance_after - player1_balance_before
+        print("player1_bet payout: ", player1_payout)
+
+        print("player2_balance_before: ", player2_balance_before)
+        print("player2_balance_after: ", player2_balance_after)
+        player2_payout = player2_balance_after - player2_balance_before
+        print("player2_bet payout: ", player2_payout)
+
+        player1_bet = self.nodes[0].getbetbytxid(player1_bet_tx)
+        player2_bet = self.nodes[0].getbetbytxid(player2_bet_tx)
+
+        assert_equal(player1_bet[0]['payout'], Decimal(player1_payout))
+        assert_equal(Decimal(player2_payout), Decimal(0))
+        assert_equal(player2_bet[0]['payout'], Decimal(player2_payout))
+
+
+        self.log.info("Revering...")
+        current_chain_height = self.nodes[0].getblockcount()
+        self.nodes[4].rpchost = self.get_local_peer(4, True)
+        self.nodes[4].start()
+        self.nodes[4].wait_for_rpc_connection()
+        self.log.info("Generate blocks...")
+        blocks = current_chain_height - revert_chain_height + 1
+        for i in range(blocks):
+            self.nodes[4].generate(1)
+            time.sleep(0.5)
+
+        self.log.info("Connect and sync nodes...")
+        self.connect_and_sync_blocks()
+
+        assert_equal(player1_balance_before, self.nodes[2].getbalance())
+        assert_equal(player2_balance_before, self.nodes[3].getbalance())
+
+        assert_raises_rpc_error(-8, "Can't find bet's transaction id: {} in chain.".format(player1_bet_tx),
+            self.nodes[0].getbetbytxid, player1_bet_tx)
+        assert_raises_rpc_error(-8, "Can't find bet's transaction id: {} in chain.".format(player2_bet_tx),
+            self.nodes[0].getbetbytxid, player2_bet_tx)
+
+
+
+    def run_test(self):
+        self.check_minting()
+        # Chain height = 300 after minting -> v4 protocol active
+        self.check_mapping()
+        self.check_hybrid_parlay_bets()
+
+if __name__ == '__main__':
+    HybridBettingTest().main()
+    # check_calculate_odds()

--- a/test/functional/feature_sporks.py
+++ b/test/functional/feature_sporks.py
@@ -43,7 +43,7 @@ class SporkTest(WagerrTestFramework):
         # check spork propagation for connected nodes
         spork_new_state = not spork_default_state
         self.set_test_spork_state(self.nodes[0], spork_new_state)
-        wait_until(lambda: self.get_test_spork_state(self.nodes[1]), sleep=0.1, timeout=10)
+        wait_until(lambda: self.get_test_spork_state(self.nodes[1]), sleep=0.1, timeout=60)
 
         # restart nodes to check spork persistence
         self.stop_node(0)

--- a/test/functional/rpc_token_test_pt1.py
+++ b/test/functional/rpc_token_test_pt1.py
@@ -5,7 +5,7 @@
 """Test the functionality of all CLI commands.
 
 """
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import WagerrTestFramework
 
 from test_framework.util import *
 
@@ -18,20 +18,22 @@ import os
 import subprocess
 
 WAGERR_TX_FEE = 0.001
-WAGERR_AUTH_ADDR = "TJA37d7KPVmd5Lqa2EcQsptcfLYsQ1Qcfk"
+WAGERR_AUTH_ADDR = "TDn9ZfHrYvRXyXC6KxRgN6ZRXgJH2JKZWe"
 
-class TokenTest (BitcoinTestFramework):
+class TokenTest (WagerrTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
-        #self.extra_args = [["-debug"],["-debug"]]
+        self.mn_count = 0
+        self.extra_args = [["-debug"], ["-debug"]]
+        self.fast_dip3_enforcement = False
 
     def run_test(self):
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
         tmpdir=self.options.tmpdir
         self.log.info("Generating Tokens...")
         self.nodes[0].generate(100)
-        self.nodes[0].importprivkey("TGVmKzjo3A4TJeBjU95VYZERj5sUq5BM68rv5UzT5KVszdgy5JCK")
+        self.nodes[0].importprivkey("TCH8Qby7krfugb2sFWzHQSEmTxBgzBSLkgPtt5EUnzDqfaX9dcsS")
         self.nodes[0].generate(100)
         self.nodes[0].generate(100)
         self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
@@ -43,22 +45,33 @@ class TokenTest (BitcoinTestFramework):
         LiveBLS=self.nodes[0].bls("generate")
         HulkBLS=self.nodes[0].bls("generate")
         self.log.info("MGTBLS %s" % MGTBLS["public"])
+        self.log.info("ORATBLS %s" % ORATBLS["public"])
         MGTAddr=self.nodes[0].getnewaddress()
         ORATAddr=self.nodes[0].getnewaddress()
         XWAGERRAddr=self.nodes[0].getnewaddress()
         PARTAddr=self.nodes[0].getnewaddress()
         LIVEAddr=self.nodes[0].getnewaddress()
         HulkAddr=self.nodes[0].getnewaddress()
-        MGT=self.nodes[0].configuremanagementtoken( "MGT", "Management", "https://www.google.com", "0", "4", MGTBLS["public"], "false", "true")
-        self.nodes[0].generate(1)
+        self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
+        self.nodes[0].generate(100)
+        self.nodes[0].generate(100)
+        MGT=self.nodes[0].configuremanagementtoken( "MGT", "Management", "4", "https://www.google.com", "0",  MGTBLS["public"], "false", "true")
         self.log.info("MGT %s" % MGT)
         MGTGroup_ID=MGT['groupID']
+        self.nodes[0].generate(100)
+        breakpoint()
         self.nodes[0].minttoken(MGTGroup_ID, MGTAddr, '82')
         self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
         self.nodes[0].generate(1)
         mintaddr=self.nodes[0].getnewaddress()
         self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
         self.nodes[0].minttoken(MGTGroup_ID, mintaddr, 500)
+        self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
+        self.nodes[0].generate(1)
+        ORAT=self.nodes[0].configuremanagementtoken( "ORAT", "ORAT", "4", "https://www.google.com", "0",  ORATBLS["public"], "false", "true")
+        self.log.info("ORAT %s" % ORAT)
+        ORATGroup_ID=ORAT['groupID']
+        self.nodes[0].minttoken(ORATGroup_ID, ORATAddr, '82')
         self.nodes[0].sendtoaddress(WAGERR_AUTH_ADDR, 10)
         self.nodes[0].generate(1)
         XWAGERRTok=self.nodes[0].configuremanagementtoken("XWAGERR", "ExtraWagerr", "https://github.com/wagerr/ATP-descriptions/blob/master/WAGERR-testnet-XWAGERR.json","f5125a90bde180ef073ce1109376d977f5cbddb5582643c81424cc6cc842babd","0", XWAGERRBLS["public"], "true", "true")

--- a/test/functional/test_framework/betting_opcode.py
+++ b/test/functional/test_framework/betting_opcode.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import struct
+import subprocess
+from test_framework.util import bytes_to_hex_str
+from test_framework.messages import COIN
+
+OPCODE_PREFIX = 42
+
+OPCODE_BTX_MAPPING = 0x01
+OPCODE_BTX_EVENT = 0x02
+OPCODE_BTX_BET = 0x03
+OPCODE_BTX_RESULT = 0x04
+OPCODE_BTX_UPDATE_ODDS = 0x05
+OPCODE_BTX_CG_EVENT = 0x06
+OPCODE_BTX_CG_BET = 0x07
+OPCODE_BTX_CG_RESULT = 0x08
+OPCODE_BTX_SPREAD_EVENT = 0x09
+OPCODE_BTX_TOTALS_EVENT = 0x0a
+OPCODE_BTX_EVENT_PATCH = 0x0b
+OPCODE_BTX_PARLAY_BET = 0x0c
+OPCODE_BTX_QG_BET = 0x0d
+OPCODE_BTX_ZERO_ODDS = 0x0e
+OPCODE_BTX_FIELD_EVENT = 0x0f
+OPCODE_BTX_FIELD_UPDATE_ODDS = 0x10
+OPCODE_BTX_FIELD_ZEROING_ODDS = 0x11
+OPCODE_BTX_FIELD_RESULT = 0x12
+
+OPCODE_QG_DICE = 0x00
+
+SPORT_MAPPING      = 0x01
+ROUND_MAPPING      = 0x02
+TEAM_MAPPING       = 0x03
+TOURNAMENT_MAPPING = 0x04
+INDIVIDUAL_SPORT_MAPPING    = 0x05
+CONTENDER_MAPPING           = 0x06
+
+STANDARD_RESULT = 0x01
+EVENT_REFUND    = 0x02
+ML_REFUND       = 0x03
+SPREADS_REFUND  = 0x04
+TOTALS_REFUND   = 0x05
+EVENT_CLOSED    = 0x06
+
+WGR_TX_FEE = 0.001
+
+QG_DICE_EQUAL = 0x00
+QG_DICE_NOT_EQUAL = 0x01
+QG_DICE_TOTAL_OVER = 0x02
+QG_DICE_TOTAL_UNDER = 0x03
+QG_DICE_EVEN = 0x04
+QG_DICE_ODD = 0x05
+
+ODDS_DIVISOR = 10000
+BETX_PERMILLE = 60
+
+# Encode an unsigned int in hexadecimal and little endian byte order. The function expects the value and the size in
+# bytes as parameters.
+def encode_int_little_endian(value: int, size: int):
+    if size == 1:
+        return struct.pack('<B', int(value)).hex()
+    elif size == 2:
+        return struct.pack('<H', int(value)).hex()
+    elif size == 4:
+        return struct.pack('<I', int(value)).hex()
+    else:
+        raise RuntimeError("Incorrect byte size was specified for encoding.")
+
+def encode_signed_int_little_endian(value: int, size: int):
+    if size == 1:
+        return struct.pack('<b', int(value)).hex()
+    elif size == 2:
+        return struct.pack('<h', int(value)).hex()
+    elif size == 4:
+        return struct.pack('<i', int(value)).hex()
+    else:
+        raise RuntimeError("Incorrect byte size was specified for encoding.")
+
+# Encode a string in hexadecimal notation. Byte order does not matter for UTF-8 encoded strings, however, I have kept
+# used similar encoding methods as I would to encode in little-endian byte order to keep things consistent with int
+# handling. The end result for a string is the same for little/big endian.
+#
+# There is no limit to the size of the encoded string as the function will use the length of the string.
+def encode_str_hex(value: str):
+    value = bytes(value.encode('utf8'))
+    return struct.pack("<%ds" % (len(value)), value).hex()
+
+# Create a common opcode.
+def make_common_header(btx_type, version = 1):
+    prefix = str(OPCODE_PREFIX)
+    version_hex = encode_int_little_endian(version, 1)
+    btx_type_hex = encode_int_little_endian(btx_type, 1)
+    return prefix + version_hex + btx_type_hex
+
+# Create a mapping opcode.
+def make_mapping(namespace_id, mapping_id, mapping_name):
+    mapping_id_size = 2 if namespace_id != 3 and namespace_id != 6 else 4
+    result = make_common_header(OPCODE_BTX_MAPPING)
+    result = result + encode_int_little_endian(namespace_id, 1)
+    result = result + encode_int_little_endian(mapping_id, mapping_id_size)
+    for sym in mapping_name:
+        result = result + encode_int_little_endian(ord(sym), 1)
+    return result
+
+# Create a moneyline patch opcode.
+def make_event_patch(event_id, timestamp):
+    result = make_common_header(OPCODE_BTX_EVENT_PATCH)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(timestamp, 4)
+    return result
+
+# Create a moneyline event opcode.
+def make_event(event_id, timestamp, sport, tournament, round, home_team, away_team, home_odds, away_odds, draw_odds):
+    result = make_common_header(OPCODE_BTX_EVENT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(timestamp, 4)
+    result = result + encode_int_little_endian(sport, 2)
+    result = result + encode_int_little_endian(tournament, 2)
+    result = result + encode_int_little_endian(round, 2)
+    result = result + encode_int_little_endian(home_team, 4)
+    result = result + encode_int_little_endian(away_team, 4)
+    result = result + encode_int_little_endian(home_odds, 4)
+    result = result + encode_int_little_endian(away_odds, 4)
+    result = result + encode_int_little_endian(draw_odds, 4)
+    return result
+
+# Create a field event opcode
+def make_field_event(event_id, timestamp, group, marketType, sport, tournament, round, mrg_in_percent, contenders_win_odds):
+    result = make_common_header(OPCODE_BTX_FIELD_EVENT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(timestamp, 4)
+    result = result + encode_int_little_endian(sport, 2)
+    result = result + encode_int_little_endian(tournament, 2)
+    result = result + encode_int_little_endian(round, 2)
+    result = result + encode_int_little_endian(group, 1)
+    result = result + encode_int_little_endian(marketType, 1)
+    result = result + encode_int_little_endian(mrg_in_percent, 4)
+    result = result + encode_int_little_endian(int(len(contenders_win_odds)), 1) # map size
+    for contender_id, contender_odds in contenders_win_odds.items():
+        result = result + encode_int_little_endian(int(contender_id), 4)
+        result = result + encode_int_little_endian(int(contender_odds), 4)
+    return result
+
+# Create an update odds for field event opcode
+def make_field_update_odds(event_id, contenders_win_odds):
+    result = make_common_header(OPCODE_BTX_FIELD_UPDATE_ODDS)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(int(len(contenders_win_odds)), 1) # map size
+    for contender_id, contender_odds in contenders_win_odds.items():
+        result = result + encode_int_little_endian(int(contender_id), 4)
+        result = result + encode_int_little_endian(int(contender_odds), 4)
+    return result
+
+# Create an zeroing odds for field event opcode
+def make_field_zeroing_odds(event_id):
+    result = make_common_header(OPCODE_BTX_FIELD_ZEROING_ODDS)
+    result = result + encode_int_little_endian(event_id, 4)
+    return result
+
+# Create a result for field event opcode
+def make_field_result(event_id, result_type, contenders_results):
+    result = make_common_header(OPCODE_BTX_FIELD_RESULT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(result_type, 1)
+    result = result + encode_int_little_endian(int(len(contenders_results)), 1) # map size
+    for contender_id, contender_result in contenders_results.items():
+        result = result + encode_int_little_endian(int(contender_id), 4)
+        result = result + encode_int_little_endian(int(contender_result), 1)
+    return result
+
+# Create a moneyline odds update opcode.
+def make_update_ml_odds(event_id, home_odds, away_odds, draw_odds):
+    result = make_common_header(OPCODE_BTX_UPDATE_ODDS)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(home_odds, 4)
+    result = result + encode_int_little_endian(away_odds, 4)
+    result = result + encode_int_little_endian(draw_odds, 4)
+    return result
+
+def make_zeroing_odds(event_ids):
+    result = make_common_header(OPCODE_BTX_ZERO_ODDS)
+    result = result + encode_int_little_endian(int(len(event_ids)), 1) # vector size
+    for event_id in event_ids:
+        result = result + encode_int_little_endian(int(event_id), 4)
+    return result
+
+# Create a spread event
+def make_spread_event(event_id, points, home_odds, away_odds):
+    result = make_common_header(OPCODE_BTX_SPREAD_EVENT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_signed_int_little_endian(points, 2)
+    result = result + encode_int_little_endian(home_odds, 4)
+    result = result + encode_int_little_endian(away_odds, 4)
+    return result
+
+# Create a total event
+def make_total_event(event_id, points, over_odds, under_odds):
+    result = make_common_header(OPCODE_BTX_TOTALS_EVENT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(points, 2)
+    result = result + encode_int_little_endian(over_odds, 4)
+    result = result + encode_int_little_endian(under_odds, 4)
+    return result
+
+def make_result(event_id, result_type, home_score, away_score):
+    result = make_common_header(OPCODE_BTX_RESULT)
+    result = result + encode_int_little_endian(event_id, 4)
+    result = result + encode_int_little_endian(result_type, 1)
+    result = result + encode_int_little_endian(home_score, 2)
+    result = result + encode_int_little_endian(away_score, 2)
+    return result
+
+def make_chain_games_event(event_id, fee):
+    result = make_common_header(OPCODE_BTX_CG_EVENT)
+    result = result + encode_int_little_endian(event_id, 2)
+    result = result + encode_int_little_endian(fee, 2)
+    return result
+
+def make_chain_games_result(event_id):
+    result = make_common_header(OPCODE_BTX_CG_RESULT)
+    result = result + encode_int_little_endian(event_id, 2)
+    return result
+
+def get_utxo_list(node, address, min_amount=WGR_TX_FEE):
+    utxo_array = []
+    total_amount = float(0.00)
+
+    # Find enough UTXO to use in a spend transaction to cover the minimum amount.
+    list_unspent = node.listunspent(1, 9999999, [address])
+    assert(len(list_unspent) > 0)
+    for utxo in list_unspent:
+        utxo_array.append({'txid': utxo["txid"], 'vout': utxo["vout"]})
+        total_amount += float(utxo['amount'])
+        if total_amount > min_amount:
+            break
+
+    return utxo_array, total_amount
+
+def post_opcode(node, opcode, address):
+    # Get unspent outputs to use as inputs (spend).
+    inputs, spend = get_utxo_list(node, address)
+    # Calculate the change by subtracting the transaction fee from the UTXO's value.
+    change = float(spend)
+    # Create the output JSON
+    outputs = {address: change, 'data': opcode}
+    # Create the raw transaction.
+    trx = node.createrawtransaction(inputs, outputs)
+    # Add a fee rate
+    node.fundrawtransaction(trx, {'feeRate':'0.03'})
+    # Sign the raw transaction.
+    trx = node.signrawtransactionwithwallet(trx)
+    return node.sendrawtransaction(trx['hex'])
+
+def post_raw_opcode(node, ctxout, address):
+    # Get unspent outputs to use as inputs (spend).
+    inputs, spend = get_utxo_list(node, address)
+    # Calculate the change by subtracting the transaction fee from the UTXO's value.
+    change = float(spend - ctxout.nValue / COIN)
+
+    # Create the output JSON
+    outputs = {address: change, 'ctxout': bytes_to_hex_str(ctxout.serialize())}
+
+    # Create the raw transaction.
+    trx = node.createrawtransaction(inputs, outputs)
+
+    # Sign the raw transaction.
+    trx = node.signrawtransaction(trx)
+    return node.sendrawtransaction(trx['hex'])
+
+# Create dice game bet.
+def make_dice_bet(dice_type, number = 1):
+    result = make_common_header(OPCODE_BTX_QG_BET)
+    result = result + encode_int_little_endian(OPCODE_QG_DICE, 1)
+    if dice_type != QG_DICE_EVEN and dice_type != QG_DICE_ODD:
+        result = result + encode_int_little_endian(5, 1) # vector size
+        result = result + encode_int_little_endian(dice_type, 1)
+        result = result + encode_int_little_endian(number, 4)
+    else:
+        result = result + encode_int_little_endian(1, 1) # vector size
+        result = result + encode_int_little_endian(dice_type, 1)
+    return result
+
+def calc_effective_odds(onchain_odds):
+    return ((onchain_odds - ODDS_DIVISOR) * 9400) // ODDS_DIVISOR + ODDS_DIVISOR

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -20,7 +20,7 @@ from io import BytesIO
 MAX_BLOCK_SIGOPS = 20000
 
 # Genesis block time (regtest)
-TIME_GENESIS_BLOCK = 1417713337
+TIME_GENESIS_BLOCK = 1524496462
 
 def create_block(hashprev, coinbase, ntime=None, *, version=1):
     """Create a block (with regtest difficulty)."""

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -55,7 +55,7 @@ from .util import (
     get_chain_folder,
 )
 
-WAGERR_AUTH_ADDR = "TJA37d7KPVmd5Lqa2EcQsptcfLYsQ1Qcfk"
+WAGERR_AUTH_ADDR = "TDn9ZfHrYvRXyXC6KxRgN6ZRXgJH2JKZWe"
 
 class TestStatus(Enum):
     PASSED = 1
@@ -413,8 +413,7 @@ class WagerrTestFramework(metaclass=WagerrTestMetaClass):
             except JSONRPCException as e:
                 assert str(e).startswith('Method not found')
                 continue
-
-            n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
+            #n.importprivkey(privkey=n.get_deterministic_priv_key().key, label='coinbase')
 
     def run_test(self):
         """Tests must override this method to define test logic"""
@@ -928,6 +927,7 @@ class WagerrTestFramework(WagerrTestFramework):
     def remove_masternode(self, idx):
         mn = self.mninfo[idx]
         rawtx = self.nodes[0].createrawtransaction([{"txid": mn.collateral_txid, "vout": mn.collateral_vout}], {self.nodes[0].getnewaddress(): 999.9999})
+        self.nodes[0].fundrawtransaction(rawtx['hex'], '{"feeRate":3000}')
         rawtx = self.nodes[0].signrawtransactionwithwallet(rawtx)
         self.nodes[0].sendrawtransaction(rawtx["hex"])
         self.nodes[0].generate(1)
@@ -1011,12 +1011,12 @@ class WagerrTestFramework(WagerrTestFramework):
         spork4height=500
         if not self.fast_dip3_enforcement:
             spork4height = self.nodes[0].getblockcount() + 1
-            self.nodes[0].spork("SPORK_4_DIP0003_ENFORCED", spork4height)
+            self.nodes[0].sporkupdate("SPORK_4_DIP0003_ENFORCED", spork4height)
             self.wait_for_sporks_same()
             while self.nodes[0].getblockcount() < spork4height:
                 self.nodes[0].generate(10)
         else:
-            self.nodes[0].spork("SPORK_4_DIP0003_ENFORCED", 50)
+            self.nodes[0].sporkupdate("SPORK_4_DIP0003_ENFORCED", 50)
             self.wait_for_sporks_same()
         self.sync_all()
 
@@ -1039,7 +1039,7 @@ class WagerrTestFramework(WagerrTestFramework):
             force_finish_mnsync(self.nodes[i + 1])
 
         # Enable InstantSend (including block filtering) and ChainLocks by default
-        self.nodes[0].spork("SPORK_4_DIP0003_ENFORCED", spork4height)
+        self.nodes[0].sporkupdate("SPORK_4_DIP0003_ENFORCED", spork4height)
         self.nodes[0].sporkupdate("SPORK_2_INSTANTSEND_ENABLED", 0)
         self.nodes[0].sporkupdate("SPORK_3_INSTANTSEND_BLOCK_FILTERING", 0)
         self.nodes[0].sporkupdate("SPORK_19_CHAINLOCKS_ENABLED", 0)
@@ -1296,7 +1296,7 @@ class WagerrTestFramework(WagerrTestFramework):
         wait_until(check_dkg_comitments, timeout=timeout, sleep=1)
 
     def wait_for_quorum_list(self, quorum_hash, nodes, timeout=15, sleep=2, llmq_type_name="llmq_test"):
-        self.nodes[0].spork("SPORK_4_DIP0003_ENFORCED", 10)
+        self.nodes[0].sporkupdate("SPORK_4_DIP0003_ENFORCED", 10)
         def wait_func():
             self.log.info("quorums: " + str(self.nodes[0].quorum("list")))
             if quorum_hash in self.nodes[0].quorum("list")[llmq_type_name]:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -136,26 +136,26 @@ class TestNode():
     AddressKeyPair = collections.namedtuple('AddressKeyPair', ['address', 'key'])
     PRIV_KEYS = [
             # address , privkey
-            AddressKeyPair('yYdShjQSptFKitYLksFEUSwHe4hnbar5rf', 'cMfbiEsnG5b8Gwm6vEgfWvZLuXZNC4zsN2y7Es3An9xHRWRjmwgR'),
-            AddressKeyPair('yfTFJgvq65UZsb9RBbpdYAAzsJoCGXqH2w', 'cStuFACUD1N6JjKQxNLUQ443qJUtSzLitKKEkA8x6utxTPZTLUtA'),
-            AddressKeyPair('yU3w4VDjKhHiZpWszkUZVnFTS56AfgdfPV', 'cQb5yh2sTiG7dsxxbXHhWSBLMByYT7jY49A1kC7zKhgL9WNHysWW'),
-            AddressKeyPair('yYhzix2R5LiYnDixsUnF8XwBYGYpyeTgB4', 'cW9Gu6uU4KoZJQcdyUvjULNRg4C8srPJw1adhgdTZMr9YQdKHtcn'),
-            AddressKeyPair('yiQ3qLx5L1BW9XA6JAG7hC8UQDktcBCeYG', 'cSq7gHVC1QPsswyX2pE5C38UnWZXfCLr7XnkjnDwuZ68NkWp183T'),
-            AddressKeyPair('yUL8h8mR7aNDRsU5zhcDbpp6YtA6ieUtK2', 'cTk7hiDKgxZX3JSb37vywdYYjjJows4DQjEaxBJDGF6LC6GXvPKo'),
-            AddressKeyPair('yfy21e12jn3A3uDicNehCq486o9fMwJKMc', 'cMuko9rLDbtxCFWuBSrFgBDRSMxsLWKpJKScRGNuWKbhuQsnsjKT'),
-            AddressKeyPair('yURgENB3b2YRMWnbhKF7iGs3KoaVRVXsJr', 'cQhdjTMh57MaHCDk9FsWGPtftRMBUuhaYAtouWnetcewmBuSrLSM'),
-            AddressKeyPair('yYC9AxBEUs3ZZxfcQvj2LUF5PVxxtqaEs7', 'cQFueiiP13mfytV3Svoe4o4Ux79fRJvwuSgHapXsnBwrHod57EeL'),
-            AddressKeyPair('yVs9jXGyLWLLFbpESnoppk7F8DtXcuCCTf', 'cN55daf1HotwBAgAKWVgDcoppmUNDtQSfb7XLutTLeAgVc3u8hik'),
-            AddressKeyPair('yV3eqNNshZJ4Pv6NCyYsbdJb1ERFFygFqf', 'cT7qK7g1wkYEMvKowd2ZrX1E5f6JQ7TM246UfqbCiyF7kZhorpX3'),
-            AddressKeyPair('yfE8gZCiFW9Uqu21v3JGibr3WVSPQWmY8n', 'cPiRWE8KMjTRxH1MWkPerhfoHFn5iHPWVK5aPqjW8NxmdwenFinJ'),
-            AddressKeyPair('yLLVXzya7GzmVkjQzsCG4iDpqYJyJFDSEV', 'cVLCocFyWxzyCwEknkWvDeWneTBsh9Jf3u4yiJCYjcy3gt8Jw1cM'),
-            AddressKeyPair('yLNNR3HeJxgR669oRePksYmCqHuPUG79mF', 'cQawC3oUgoToGDJBw1Ub2PpDmf44kVtcaVaTcHyzXMRKGwdn9UYW'),
-            AddressKeyPair('yLPKVwRTXME7Q3JfKAPJ4FHEaGdWgJuhpj', 'cVcFaWTbkCUZPFTHfDs8iHurPWns5QXc5rqcfkPMHUdmv17o8UYB'),
-            AddressKeyPair('yLPUundzTpvjU8KYVyM4Zmnr4REf3FFvhZ', 'cRVeRmRaYuEYP9HbCZFsf1ifYYZ4KQD9rttRoTNb9wjPzhvRwqMb'),
-            AddressKeyPair('yLRhHqau58AS1ALtnaowv1Pyztxi1Q6fXG', 'cNYFW52pJswYbfPR9fpiRpWHEQygg5tyMih2ASPsgMgPy9SUSSEV'),
-            AddressKeyPair('yLRwHeMkXwYrkDzC4q12vej243AyTeWiPm', 'cRqfZ3dAp8BJUcGhSv7ueCXNGbki1bpcXEKk5dEJN344H52GuHQY'),
-            AddressKeyPair('yLTMCXJhG1mpaWhbHcsr7zUt9wDWuQSPSk', 'cVWGbeCT5QcVORATL5NuiLs9JfL8HFDb9PN5Gq2xudw6ZsDFeDy1V'),
-            AddressKeyPair('yLU9vxiAWUdiKKxn6EazLDFq9WXrK2T7RP', 'cVCzrzfxMhUMxV34UhTmdmntAqHvosAuNo2KUZsiHZSKLm73g35o'),
+            AddressKeyPair('Tp2wuzGwtPsaixsGVK5farNoY1wi52SQxH', 'NLuyhQn6pQEo2Yo6uvV86PogGdENwJi96sEFYFNmbAY6tvyChS16'),
+            AddressKeyPair('ThS4VhDJ3Axpj1BsCnLnyXgWY46khrbCWi', 'NKYNbKbeVhNvadSYKuX6ekS2m4WwCiZvSWG2neYG1ytxc3vom5Nq'),
+            AddressKeyPair('TuYdUYrd54mxZk3jjaHKdKyqtiehH1Qqjm', 'NM66dpnRRqcgQeiHaPeCK47HgmMbGS9WLLqpc334gMLVmoauPPxL'),
+            AddressKeyPair('TwFYrydfXVG7zZaX98hN8zq3t1Ra9RKXSB', 'NJZFCodw16NH6mtDSYSU4Tbx9uCig1CgairprYdAok5SAaUsZSDp'),
+            AddressKeyPair('TqjLrmGEqxspMtZhDLc7wy3zjPNEoUPmhq', 'NJunYHT37SEYhmSJhs6xTXnxYBuTj93hjXer36yBUEqLj9KM214h'),
+            AddressKeyPair('TnVVuQ3BjZ8TgP3rbQYbM28ZURKmhijk38', 'NNq53nVUGYUqTeuuzGyP2DrzFmKhVrqAgPUiEAYw3SBKMJ41BqtB'),
+            AddressKeyPair('TdRkWMeASPL3pi2rRbdST8AtYV69t1VzSG', 'NLRhmwDmPkr1NC54NXLvx4KAnfz92z1VVgJG15od2E6X42JuyPVx'),
+            AddressKeyPair('To1dpzFgFK59ywJRyuj35cqsmC9huhdFsv', 'NPnPE8nunAbBUWTPY9ac3fYp7YfwTxnEaPuDB5mcyTEL2RHrhmoK'),
+            AddressKeyPair('Tjh7agqsebtVXhLqL75VYSheAJ1PWziqUM', 'NSfhTMnXvj9ypUjcyY7jUcFNAdzk5uV1axdfJm32qeVJUZpD5sQi'),
+            AddressKeyPair('Tjh7agqsebtVXhLqL75VYSheAJ1PWziqUM', 'NSfhTMnXvj9ypUjcyY7jUcFNAdzk5uV1axdfJm32qeVJUZpD5sQi'),
+            AddressKeyPair('ToUTCSjAS6etUBMEvgqtNY8nAbW24AF4cx', 'NQxoWZeHhJg9Tn1EVZzAUCmGRaDcn43YCyNXD98enD3bgkh6J2Va'),
+            AddressKeyPair('TcuC7dmGpsrr3B5YX2yxKAX1XcAKhs4sMH', 'NJqxZigjV1tAwjyYYZBqypSjyjuiEaknEqKbjzDbfYzrLrjPHDCA'),
+            AddressKeyPair('TeTcYY5axdpk7RaUB4cQmo3ZWB4SchJoxu', 'NKMNYrvwRCkyVCRofvtYc1mm6NRRzrkjE2gJS323CYVPKfTySK57'),
+            AddressKeyPair('TnpHYEGEs9roZMWENggcbB4eNDNyQyV6nm', 'NL7bKDBhB2S4tJXy28ynGNR9MkQj2x7k8nsJLSfufqGhmXA6jGag'),
+            AddressKeyPair('Tjc2jAku1by1kTFZKjHHkQYT2LqhvRXoTn', 'NKWp32tLu5VwV1PrWCvozRtukndUv45EKNXHxDBbb9P6hFJwUeLD'),
+            AddressKeyPair('TdjE3Xyq4gDQ2EETLSdqQeBWSaeQyE6Lvv', 'NKipjL5F5mWh62TQPfShjexFi2ERcwhr9ZqMBeEQHTBzcKvCpHph'),
+            AddressKeyPair('ThMJS9eF8zpaPxhBwsFur1xXR9w8dDbdA6', 'NLPAjt8LD6FtXowM4mGR5A1bvpP32Ju5jg8HddusRutfSEum8SqP'),
+            AddressKeyPair('Tryuo4UbUMdMkA8K3GP6wgbQqm7vH15yjj', 'NMHZNRnJbNeUwVJiAgXpMGEAysQMWjz41AyHt3Tt5TVnHMnhxyJj'),
+            AddressKeyPair('TmhXvGgLiRDcbmAs5PFVegLfX8FksWN3x3', 'NQ6ZRLuZKFR6Ah5PQVMj78SdCdSoFUh5BAwES9fWPgGwc74TJYi6'),
+            AddressKeyPair('TvhoZDE5yE9V5bpxCcHuXP5qGi9qQaghs8', 'NPcyZvxdVYocBrjvM524UNPbhpkL6ZZ3yQDhNrkeWFEHfBxEmmEr'),
     ]
 
     def get_deterministic_priv_key(self):
@@ -276,9 +276,9 @@ class TestNode():
             time.sleep(1.0 / poll_per_s)
         self._raise_assertion_error("Unable to connect to wagerrd")
 
-    def generate(self, nblocks, maxtries=1000000):
-        self.log.debug("TestNode.generate() dispatches `generate` call to `generatetoaddress`")
-        return self.generatetoaddress(nblocks=nblocks, address=self.get_deterministic_priv_key().address, maxtries=maxtries)
+    #def generate(self, nblocks):
+    #    self.log.debug("TestNode.generate() dispatches `generate` call to `generatetoaddress`")
+    #    return self.generate(nblocks=nblocks)
 
     def get_wallet_rpc(self, wallet_name):
         if self.use_cli:


### PR DESCRIPTION
This is part 1 of functional test fixes

-Remove deterministic key import
-Switch to generate from generatetoaddress
-Change genesis time to 1417713337
-Add in restart
-Add in disconnect nodes
-Add in sync nodes
-Add in getwalletinfo for balance_mining
-Add in check for spendable balance
-Add in bytes_to_hex_str to util
-Add COIN from messages in betting opcode
-Change to WagerrTestFramework in betting scripts
-Add sync_nodes in test framework and util
-Add sync blocks to util
-Add breakpoint to test_node
-Remove get_deterministic_priv_key from test_framework -Remove address check from feature_betting
-Add dicconnect/reconnect then sync in feature_betting -Add restart in feature_betting
-Add stop start in feature_betting
-Add signrawtransactionwithwallet to betting_opcode -Add settxfee to betting_opcode
-Add settxfee to feature_betting
-Set <fee-rate> using fundrawtransaction
-Set fee in feature betting
-Change timeout to 60 seconds in feature sporks
-Change node syncing method
-Add rawtransaction fee in betting_opcode
-Disable ml bets for the time being (listbetsdb not working properly) -Initialize bets in totals bets
-Change sync in dip3 deterministic mns
-Remove address equality check from field_betting as it's using generate rather than generatetoaddress -Change to node connect to get syncing to work
-Add node disconnect to get syncing to work
-Add node restart to get syncing to work
-Remove address chack from minting as minting takes place over a number of addresses -Change to a functional start/stop before the generate 51 sync -Generate to block 501 for beting v4 and v5
-Add in sync workaround to feature_betting
-Add -reindex args to feature betting
-Add breakpoint to Feature betting
-Add v4 -> v5 calculation to feature betting
-Add token tests
-Add in token tests connect_nodes rather than connect_nodes_bi -Add in token tests masternode count
-Add in token tests fast dip3 enforcement false
-Change to sporkupdate to set sporks
-Change to 0 masternodes
--Change connect_nodes to 0,1
-Change connect_nodes to 0,1 2
-Change Management token creation order
-Add a generate 100 after configuremanagementtoken -Add ORAT token
-Change to 1 node remove extra args
-Add breakpoint to line 59 rpc_token_test
-Add sendto wagerr_auth_address rpc_token_test
-Move breakpoint to line 57 rpc_token_test
-Add more generation to rpc_token_test
-Add breakpoint to line 62 rpc_token_test
-Add generation for 5 blocks to mature the bets
-Remove parlay bets event incorrect
-Remove rpc error checks in mempool as assertion errors are not being raise -Generate another 5 blocks in check_timecut_refund -Add confirmed and unconfirmed balances in check_timecut_refund -Add breakpoint in check_timecut_refund
-Change result in asian spreads to match current value 2 reinstate ML bets -Add generate 5 to ML bets 2
-Add larger generation to ML bets
-Change asion bets to match wih new value of player1_total_bet -Add breakpoint to asian bets
-Add equality addition to check_bets
-Add breakpoint to check_bets 3
-Generate to block 401 zeroing_odds 2
-Remove breakpoint
--CHange to connect nodes
-Add generate to check_closing_event
-Add sleep before a generate
-Change amounts as bet amaounts have changed